### PR TITLE
Modernize block and item components for current Bedrock schemas

### DIFF
--- a/src/Blocks/AsyncInitialization.php
+++ b/src/Blocks/AsyncInitialization.php
@@ -2,20 +2,36 @@
 
 namespace Nexly\Blocks;
 
+use Closure;
+use pocketmine\block\Block;
+use pocketmine\data\bedrock\block\convert\BlockStateReader;
+use pocketmine\data\bedrock\block\convert\BlockStateWriter;
+
 /**
  * @internal
  * @deprecated
+ *
+ * @phpstan-type AsyncBlockDefinition array{
+ *     int,
+ *     Closure(int): Block,
+ *     string,
+ *     string,
+ *     string,
+ *     string,
+ *     Closure(mixed...): BlockStateWriter,
+ *     Closure(BlockStateReader): Block
+ * }
  */
 class AsyncInitialization
 {
-    /** @var array  */
+    /** @var array<string, AsyncBlockDefinition> */
     private static array $blocks = [];
 
     /**
      * Adds an asynchronous block definition.
      *
      * @param string $stringId
-     * @param array $data
+     * @param AsyncBlockDefinition $data
      * @return void
      */
     public static function addAsyncBlock(string $stringId, array $data): void
@@ -24,7 +40,7 @@ class AsyncInitialization
     }
 
     /**
-     * @return array
+     * @return array<string, AsyncBlockDefinition>
      */
     public static function getBlocks(): array
     {

--- a/src/Blocks/BlockBuilder.php
+++ b/src/Blocks/BlockBuilder.php
@@ -42,7 +42,7 @@ use Nexly\Mappings\BlockMappings;
 use Nexly\Mappings\ItemMappings;
 use Nexly\Recipes\NexlyRecipes;
 use Nexly\Recipes\Types\Recipe;
-use pocketmine\block\block;
+use pocketmine\block\Block;
 use pocketmine\block\BlockTypeIds;
 use pocketmine\block\Crops;
 use pocketmine\block\Door;
@@ -69,6 +69,7 @@ use pocketmine\data\bedrock\block\convert\BlockStateWriter;
 use pocketmine\data\bedrock\item\BlockItemIdMap;
 use pocketmine\data\bedrock\item\SavedItemData;
 use pocketmine\data\bedrock\item\upgrade\LegacyItemIdToStringIdMap;
+use pocketmine\item\Item;
 use pocketmine\item\ItemBlock;
 use pocketmine\item\StringToItemParser;
 use pocketmine\nbt\NBT;
@@ -98,16 +99,16 @@ class BlockBuilder
     private ?CreativeInfo $creativeInfo = null;
     private MaterialType $material = MaterialType::Dirt;
 
-    /** @var array<string> */
+    /** @var list<string> */
     private array $tags = [];
 
-    /** @var array<BlockComponent> */
+    /** @var array<string, BlockComponent> */
     private array $components = [];
-    /** @var array<Permutation> */
+    /** @var list<Permutation> */
     private array $permutations = [];
-    /** @var array<MinecraftTrait> */
+    /** @var list<MinecraftTrait> */
     private array $traits = [];
-    /** @var array<BlockProperty> */
+    /** @var list<BlockProperty> */
     private array $properties = [];
 
     /**
@@ -136,7 +137,7 @@ class BlockBuilder
      */
     public function setStringId(string $stringId): self
     {
-        if (str_contains("minecraft:", $stringId)) {
+        if (str_contains($stringId, "minecraft:")) {
             throw new \InvalidArgumentException("Custom block string ID cannot contain the 'minecraft:' namespace.");
         }
 
@@ -167,7 +168,7 @@ class BlockBuilder
     }
 
     /**
-     * @return array
+     * @return list<string>
      */
     public function getTags(): array
     {
@@ -175,7 +176,7 @@ class BlockBuilder
     }
 
     /**
-     * @param array $tags
+     * @param list<string> $tags
      */
     public function setTags(array $tags): void
     {
@@ -298,7 +299,7 @@ class BlockBuilder
     /**
      * Add a BlockComponent to the builder.
      *
-     * @return array
+     * @return array<string, BlockComponent>
      */
     public function getComponents(): array
     {
@@ -308,12 +309,13 @@ class BlockBuilder
     /**
      * Get a BlockComponent by its name.
      *
-     * @param BlockComponentIds $name
+     * @param BlockComponentIds|string $name
      * @return BlockComponent|null
      */
     public function getComponent(BlockComponentIds|string $name): ?BlockComponent
     {
-        return $this->components[$name?->getValue() ?? $name] ?? null;
+        $componentName = $name instanceof BlockComponentIds ? $name->getValue() : $name;
+        return $this->components[$componentName] ?? null;
     }
 
     /**
@@ -351,7 +353,7 @@ class BlockBuilder
     }
 
     /**
-     * @return array
+     * @return list<Permutation>
      */
     public function getPermutations(): array
     {
@@ -371,7 +373,7 @@ class BlockBuilder
     }
 
     /**
-     * @return array
+     * @return list<MinecraftTrait>
      */
     public function getTraits(): array
     {
@@ -391,7 +393,7 @@ class BlockBuilder
     }
 
     /**
-     * @return array
+     * @return list<BlockProperty>
      */
     public function getProperties(): array
     {
@@ -484,18 +486,19 @@ class BlockBuilder
     public function toNBT(): CompoundTag
     {
         $components = CompoundTag::create();
-        foreach ($this->components as $k => $component) {
+        foreach ($this->components as $component) {
             $components->setTag($component->getName(), $component->toNBT());
         }
 
+        /** @var list<CompoundTag> $properties */
         $properties = [];
         foreach ($this->properties as $property) {
             foreach ($this->traits as $trait) {
-                if ($trait->getState()->isCardinal() && $property->getName() == BlockStateNames::MC_CARDINAL_DIRECTION) {
+                if ($trait->getState()->isCardinal() && $property->getName() === BlockStateNames::MC_CARDINAL_DIRECTION) {
                     continue 2;
                 }
 
-                if ($trait->getState()->isFacing() && $property->getName() == BlockStateNames::FACING_DIRECTION) {
+                if ($trait->getState()->isFacing() && $property->getName() === BlockStateNames::FACING_DIRECTION) {
                     continue 2;
                 }
             }
@@ -503,19 +506,22 @@ class BlockBuilder
             $properties[] = $property->toNBT();
         }
 
+        $creativeGroup = $this->getCreativeInfo()?->getGroup()?->value;
+        $creativeGroup = is_string($creativeGroup) ? strtolower($creativeGroup) : "none";
+
         return CompoundTag::create()
             ->setTag("components", $components)
-            ->setTag("permutations", new ListTag(array_map(fn (Permutation $permutation) => $permutation->toNBT(), $this->permutations), NBT::TAG_Compound))
+            ->setTag("permutations", new ListTag(array_map(fn (Permutation $permutation): CompoundTag => $permutation->toNBT(), $this->permutations), NBT::TAG_Compound))
             ->setTag("properties", new ListTag($properties, NBT::TAG_Compound))
             ->setTag(
                 "menu_category",
                 CompoundTag::create()
-                ->setTag("category", new StringTag(strtolower($this->getCreativeInfo()?->getCategory()?->name ?? "none")))
-                ->setTag("group", new StringTag(strtolower($this->getCreativeInfo()?->getGroup()?->value ?? "none")))
-                ->setTag("is_hidden_in_commands", new ByteTag($this->getCreativeInfo()?->isHidden() ?? false))
+                ->setTag("category", new StringTag(strtolower($this->getCreativeInfo()?->getCategory()->name ?? "none")))
+                ->setTag("group", new StringTag($creativeGroup))
+                ->setTag("is_hidden_in_commands", new ByteTag(($this->getCreativeInfo()?->isHidden() ?? false) ? 1 : 0))
             )
-            ->setTag("blockTags", new ListTag(array_map(fn (string $tag) => new StringTag($tag), $this->tags), NBT::TAG_String))
-            ->setTag("traits", new ListTag(array_map(fn (MinecraftTrait $trait) => $trait->toNBT(), $this->traits), NBT::TAG_Compound))
+            ->setTag("blockTags", new ListTag(array_map(fn (string $tag): StringTag => new StringTag($tag), $this->tags), NBT::TAG_String))
+            ->setTag("traits", new ListTag(array_map(fn (MinecraftTrait $trait): CompoundTag => $trait->toNBT(), $this->traits), NBT::TAG_Compound))
             ->setTag(
                 "vanilla_block_data",
                 CompoundTag::create()
@@ -532,7 +538,7 @@ class BlockBuilder
      * @param bool $autoload
      * @return $this
      */
-    public function register(bool $creative = true, bool $autoload = true, Closure $init = null): self
+    public function register(bool $creative = true, bool $autoload = true, ?Closure $init = null): self
     {
         if (!isset($this->block)) {
             throw new \RuntimeException("Block instance is not set. Use setBlock() to set it before registering.");
@@ -548,8 +554,8 @@ class BlockBuilder
 
         $this->loadComponents($block, $autoload);
 
-        $serializer = $this->serializer ??= static fn () => new BlockStateWriter($stringId);
-        $deserializer = $this->deserializer ??= static fn (BlockStateReader $in) => clone $block;
+        $serializer = $this->serializer ??= static fn (Block $block): BlockStateWriter => new BlockStateWriter($stringId);
+        $deserializer = $this->deserializer ??= static fn (BlockStateReader $in): Block => clone $block;
 
         $entries = [];
         foreach ($this->getBlockStateDictionaryEntry() as $entry) {
@@ -564,24 +570,24 @@ class BlockBuilder
         BlockStateHandlers::getDeserializer()->map($stringId, $deserializer);
         BlockMappings::getInstance()->registerMapping(new BlockMapping($this, new BlockPaletteEntry($stringId, new CacheableNbt($this->toNBT()))));
         AsyncInitialization::addAsyncBlock($stringId, [
-            $this->numericId,
+            $numericId,
             $this->block,
-            json_encode(array_map(fn (BlockProperty $property) => [
+            json_encode(array_map(fn (BlockProperty $property): array => [
                 "name" => $property->getName(),
                 "values" => $property->getValues()
             ], $this->properties), JSON_THROW_ON_ERROR),
-            json_encode(array_map(fn (Permutation $permutation) => [
+            json_encode(array_map(fn (Permutation $permutation): array => [
                 "condition" => $permutation->getCondition(),
-                "components" => array_map(fn (BlockComponent $component) => [
+                "components" => array_map(fn (BlockComponent $component): array => [
                     "name" => $component->getName(),
                     "nbt" => base64_encode((new CacheableNbt($component->toNBT()))->getEncodedNbt())
                 ], $permutation->getComponents())
             ], $this->permutations), JSON_THROW_ON_ERROR),
-            json_encode(array_map(fn (BlockComponent $component) => [
+            json_encode(array_map(fn (BlockComponent $component): array => [
                 "name" => $component->getName(),
                 "nbt" => base64_encode((new CacheableNbt($component->toNBT()))->getEncodedNbt())
             ], $this->getComponents()), JSON_THROW_ON_ERROR),
-            json_encode(array_map(fn (MinecraftTrait $trait) => [
+            json_encode(array_map(fn (MinecraftTrait $trait): array => [
                 "identifier" => $trait->getIdentifier()->value,
                 "rotationOffset" => $trait->getRotationOffset(),
                 "state" => [
@@ -617,7 +623,7 @@ class BlockBuilder
                 if ($instance instanceof CreativeInfo) {
                     $creativeInfo = $instance;
                 } elseif ($instance instanceof Recipe) {
-                    NexlyRecipes::getInstance()->addRecipe(fn () => $attribute->newInstance());
+                    NexlyRecipes::getInstance()->addRecipe(fn (): Recipe => $instance);
                 }
             }
         }
@@ -691,8 +697,8 @@ class BlockBuilder
         $stringId = $this->getStringId();
 
         try {
-            ItemDataHandlers::getDeserializer()->map($stringId, fn (SavedItemData $data) => clone $builder->getItem());
-            ItemDataHandlers::getSerializer()->map($builder->getItem(), fn () => new SavedItemData($stringId));
+            ItemDataHandlers::getDeserializer()->map($stringId, fn (SavedItemData $data): Item => clone $builder->getItem());
+            ItemDataHandlers::getSerializer()->map($builder->getItem(), fn (Item $item): SavedItemData => new SavedItemData($stringId));
         } catch (\Throwable) {
             Server::getInstance()->getLogger()->warning("Nexly BlockBuilder: Failed to register item serializer/deserializer for block item '{$stringId}'");
         }
@@ -717,39 +723,40 @@ class BlockBuilder
         $name = $this->getName();
         $stringId = $this->getStringId();
 
-        StringToItemParser::getInstance()->registerBlock($name, fn () => clone $block);
+        StringToItemParser::getInstance()->registerBlock($name, fn (): Block => clone $block);
         LegacyItemIdToStringIdMap::getInstance()->add($name, 255 - $this->getNumericId());
 
         $blockItemIdMap = BlockItemIdMap::getInstance();
         $reflection = new ReflectionClass($blockItemIdMap);
 
         $itemToBlockId = $reflection->getProperty("itemToBlockId");
-        /** @var string[] $value */
+        /** @var array<string, string> $value */
         $value = $itemToBlockId->getValue($blockItemIdMap);
         $itemToBlockId->setValue($blockItemIdMap, $value + [$stringId => $stringId]);
     }
 
     /**
-     * @return Generator
+     * @return Generator<int, BlockStateDictionaryEntry, mixed, void>
      */
     private function getBlockStateDictionaryEntry(): Generator
     {
         if (empty($this->properties)) {
-            return yield new BlockStateDictionaryEntry($this->getStringId(), [], 0);
+            yield new BlockStateDictionaryEntry($this->getStringId(), [], 0);
+            return;
         }
 
-        $listBlockPropertyName = array_map(fn (BlockProperty $property) => $property->getName(), $this->properties);
-        $data_ = array_map(fn (BlockProperty $property) => $property->getValues(), $this->properties);
+        $listBlockPropertyName = array_map(fn (BlockProperty $property): string => $property->getName(), $this->properties);
+        $data_ = array_map(fn (BlockProperty $property): array => $property->getValues(), $this->properties);
         foreach (CartesianProduct::get($data_) as $meta => $property) {
             $states = [];
             foreach ($property as $i => $data) {
-                $states[$listBlockPropertyName[$i]] = match (true) {
-                    is_bool($data) => new ByteTag($data),
-                    is_string($data) => new StringTag($data),
-                    is_int($data) => new IntTag($data),
-                    is_float($data) => new FloatTag($data),
-                    default => throw new \RuntimeException("Invalid block property data type"),
-                };
+                if (is_bool($data)) {
+                    $states[$listBlockPropertyName[$i]] = new ByteTag($data ? 1 : 0);
+                } elseif (is_string($data)) {
+                    $states[$listBlockPropertyName[$i]] = new StringTag($data);
+                } else {
+                    $states[$listBlockPropertyName[$i]] = new IntTag($data);
+                }
             }
 
             yield new BlockStateDictionaryEntry($this->getStringId(), $states, $meta);

--- a/src/Blocks/BlockPalette.php
+++ b/src/Blocks/BlockPalette.php
@@ -17,7 +17,7 @@ final class BlockPalette
 {
     use SingletonTrait;
 
-    /** @var BlockStateDictionaryEntry[] */
+    /** @var list<BlockStateDictionaryEntry> */
     private array $states = [];
 
     public function __construct()
@@ -25,7 +25,7 @@ final class BlockPalette
     }
 
     /**
-     * @return BlockStateDictionaryEntry[]
+     * @return list<BlockStateDictionaryEntry>
      */
     public function getStates(): array
     {
@@ -45,6 +45,8 @@ final class BlockPalette
 
     /**
      * Inserts the provided state in to the correct position of the palette.
+     *
+     * @param list<BlockStateDictionaryEntry> $entries
      */
     public function insertStates(array $entries): void
     {
@@ -62,20 +64,13 @@ final class BlockPalette
     /**
      * Sorts the states using the fnv164 hash of their names.
      *
-     * @param array $states
-     * @param array|null $sortedStates
-     * @param array|null $stateDataToStateIdLookup
+     * @param array<string, list<BlockStateDictionaryEntry>> $states
+     * @param array<int, BlockStateDictionaryEntry> $sortedStates
+     * @param array<string, int|array<string, int>> $stateDataToStateIdLookup
      * @return void
      */
-    private function sort(array $states, ?array &$sortedStates, ?array &$stateDataToStateIdLookup): void
+    private function sort(array $states, array &$sortedStates, array &$stateDataToStateIdLookup): void
     {
-        if ($stateDataToStateIdLookup === null) {
-            $stateDataToStateIdLookup = [];
-        }
-        if ($sortedStates === null) {
-            $sortedStates = [];
-        }
-
         foreach ($states as $name => $blockStates) {
             $numberState = count($blockStates);
 
@@ -96,7 +91,12 @@ final class BlockPalette
                 if ($numberState === 1) {
                     $stateDataToStateIdLookup[$name] = $stateId;
                 } else {
-                    $stateDataToStateIdLookup[$name][$blockState->getRawStateProperties()] = $stateId;
+                    $lookup = $stateDataToStateIdLookup[$name] ?? [];
+                    if (!is_array($lookup)) {
+                        throw new \LogicException("Multiple states cannot share a scalar state lookup.");
+                    }
+                    $lookup[$blockState->getRawStateProperties()] = $stateId;
+                    $stateDataToStateIdLookup[$name] = $lookup;
                 }
 
                 $sortedStates[$stateId] = $blockState;
@@ -127,7 +127,7 @@ final class BlockPalette
     private static function fnv1a32(string $str): int
     {
         $hashHex = hash('fnv1a32', $str);
-        $hashInt = intval(hexdec($hashHex));
+        $hashInt = (int) hexdec($hashHex);
         if ($hashInt > 0x7FFFFFFF) {
             $hashInt -= 0x100000000;
         }

--- a/src/Blocks/Components/BlockComponentIds.php
+++ b/src/Blocks/Components/BlockComponentIds.php
@@ -4,8 +4,10 @@ namespace Nexly\Blocks\Components;
 
 enum BlockComponentIds: string
 {
+    /** @deprecated Internal client metadata, not a public block component. */
     case BREATHABILITY = "minecraft:breathability";
     case COLLISION_BOX = "minecraft:collision_box";
+    case CONNECTION_RULE = "minecraft:connection_rule";
     case DESTRUCTIBLE_BY_EXPLOSION = "minecraft:destructible_by_explosion";
     case DESTRUCTIBLE_BY_MINING = "minecraft:destructible_by_mining";
     case DISPLAY_NAME = "minecraft:display_name";
@@ -18,12 +20,15 @@ enum BlockComponentIds: string
     case LIGHT_EMISSION = "minecraft:light_emission";
     case LIQUID_DETECTION = "minecraft:liquid_detection";
     case MATERIAL_INSTANCES = "minecraft:material_instances";
+    /** @deprecated Use script event subscriptions instead. */
     case ON_INTERACT = "minecraft:on_interact";
+    /** @deprecated Use script event subscriptions instead. */
     case ON_PLAYER_PLACING = "minecraft:on_player_placing";
     case PLACEMENT_FILTER = "minecraft:placement_filter";
     case REPLACEABLE = "minecraft:replaceable";
     case SELECTION_BOX = "minecraft:selection_box";
     case TRANSFORMATION = "minecraft:transformation";
+    /** @deprecated Script custom_components is no longer supported. */
     case CUSTOM_COMPONENTS = "minecraft:custom_components";
     case FLOWER_POTTABLE = "minecraft:flower_pottable";
     case RANDOM_OFFSET = "minecraft:random_offset";

--- a/src/Blocks/Components/BreathabilityBlockComponent.php
+++ b/src/Blocks/Components/BreathabilityBlockComponent.php
@@ -7,11 +7,15 @@ use Nexly\Blocks\Components\Types\BreathabilityType;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\StringTag;
 
+/**
+ * @internal Required only by the client block-definition NBT.
+ * @deprecated Not usable as a public custom-content component.
+ */
 #[Attribute(Attribute::TARGET_CLASS)]
 class BreathabilityBlockComponent extends BlockComponent
 {
     public function __construct(
-        private BreathabilityType $type,
+        private readonly BreathabilityType $type,
     ) {
     }
 

--- a/src/Blocks/Components/CollisionBoxBlockComponent.php
+++ b/src/Blocks/Components/CollisionBoxBlockComponent.php
@@ -44,16 +44,7 @@ class CollisionBoxBlockComponent extends BlockComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("enabled", new ByteTag($this->enabled))
-            ->setTag(
-                "boxes",
-                new ListTag(
-                    array_map(
-                        fn (BoxCollision $collision) => $collision->toNBT(true),
-                        $this->collisions
-                    ),
-                    NBT::TAG_Compound
-                )
-            );
+            ->setTag("enabled", new ByteTag($this->enabled ? 1 : 0))
+            ->setTag("boxes", new ListTag(array_map(fn (BoxCollision $collision): CompoundTag => $collision->toNBT(true), $this->collisions), NBT::TAG_Compound));
     }
 }

--- a/src/Blocks/Components/ConnectionRuleComponent.php
+++ b/src/Blocks/Components/ConnectionRuleComponent.php
@@ -3,14 +3,22 @@
 namespace Nexly\Blocks\Components;
 
 use Attribute;
+use Nexly\Blocks\Components\Types\ConnectionType;
+use Nexly\Blocks\Components\Types\HorizontalFace;
+use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\StringTag;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class ConnectionRuleComponent extends BlockComponent
 {
+    /**
+     * @param list<HorizontalFace> $enabledDirections
+     */
     public function __construct(
-        private string $from = "none",
+        private readonly ConnectionType $from = ConnectionType::ALL,
+        private readonly array $enabledDirections = [HorizontalFace::SOUTH, HorizontalFace::NORTH, HorizontalFace::EAST, HorizontalFace::WEST],
     ) {
     }
 
@@ -21,7 +29,7 @@ class ConnectionRuleComponent extends BlockComponent
      */
     public function getName(): string
     {
-        return "minecraft:connection_rule";
+        return BlockComponentIds::CONNECTION_RULE->getValue();
     }
 
     /**
@@ -32,6 +40,7 @@ class ConnectionRuleComponent extends BlockComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("accepts_connections_from", new StringTag($this->from));
+            ->setTag("accepts_connections_from", new StringTag($this->from->getValue()))
+            ->setTag("enabled_directions", new ListTag(array_map(fn (HorizontalFace $direction): StringTag => new StringTag($direction->getValue()), $this->enabledDirections), NBT::TAG_String));
     }
 }

--- a/src/Blocks/Components/CustomComponentsBlockComponent.php
+++ b/src/Blocks/Components/CustomComponentsBlockComponent.php
@@ -6,13 +6,18 @@ use Attribute;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
 
+/**
+ * @internal Legacy client hook metadata retained for network compatibility.
+ * @deprecated minecraft:custom_components is no longer supported in current
+ *             custom-content definitions.
+ */
 #[Attribute(Attribute::TARGET_CLASS)]
 class CustomComponentsBlockComponent extends BlockComponent
 {
     public function __construct(
-        private bool $hasPlayerInteract = true,
-        private bool $hasPlayerPlacing = true,
-        private bool $isV1Component = true,
+        private readonly bool $hasPlayerInteract = true,
+        private readonly bool $hasPlayerPlacing = true,
+        private readonly bool $isV1Component = true,
     ) {
     }
 
@@ -34,8 +39,8 @@ class CustomComponentsBlockComponent extends BlockComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("hasPlayerInteract", new ByteTag($this->hasPlayerInteract))
-            ->setTag("hasPlayerPlacing", new ByteTag($this->hasPlayerPlacing))
-            ->setTag("isV1Component", new ByteTag($this->isV1Component));
+            ->setTag("hasPlayerInteract", new ByteTag($this->hasPlayerInteract ? 1 : 0))
+            ->setTag("hasPlayerPlacing", new ByteTag($this->hasPlayerPlacing ? 1 : 0))
+            ->setTag("isV1Component", new ByteTag($this->isV1Component ? 1 : 0));
     }
 }

--- a/src/Blocks/Components/DestructibleByExplosionBlockComponent.php
+++ b/src/Blocks/Components/DestructibleByExplosionBlockComponent.php
@@ -10,8 +10,11 @@ use pocketmine\nbt\tag\FloatTag;
 class DestructibleByExplosionBlockComponent extends BlockComponent
 {
     public function __construct(
-        private readonly float $resistance = 0.0,
+        private readonly float $explosionResistance = 0.0,
     ) {
+        if ($explosionResistance < 0.0) {
+            throw new \InvalidArgumentException("Explosion resistance cannot be negative.");
+        }
     }
 
     /**
@@ -32,6 +35,6 @@ class DestructibleByExplosionBlockComponent extends BlockComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("explosion_resistance", new FloatTag($this->resistance));
+            ->setTag("explosion_resistance", new FloatTag($this->explosionResistance));
     }
 }

--- a/src/Blocks/Components/DestructibleByMiningBlockComponent.php
+++ b/src/Blocks/Components/DestructibleByMiningBlockComponent.php
@@ -3,15 +3,25 @@
 namespace Nexly\Blocks\Components;
 
 use Attribute;
+use Nexly\Blocks\Components\Types\ItemSpecificSpeed;
+use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\FloatTag;
+use pocketmine\nbt\tag\ListTag;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class DestructibleByMiningBlockComponent extends BlockComponent
 {
+    /**
+     * @param list<ItemSpecificSpeed> $itemSpecificSpeeds
+     */
     public function __construct(
-        private readonly float $duration = 0.0,
+        private readonly float $secondsToDestroy = 0.0,
+        private readonly array $itemSpecificSpeeds = [],
     ) {
+        if ($secondsToDestroy < 0.0) {
+            throw new \InvalidArgumentException("Seconds to destroy cannot be negative.");
+        }
     }
 
     /**
@@ -32,6 +42,8 @@ class DestructibleByMiningBlockComponent extends BlockComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("value", new FloatTag($this->duration));
+            ->setTag("value", new FloatTag($this->secondsToDestroy))
+            ->setTag("seconds_to_destroy", new FloatTag($this->secondsToDestroy))
+            ->setTag("item_specific_speeds", new ListTag(array_map(fn (ItemSpecificSpeed $speed): CompoundTag => $speed->toNBT(), $this->itemSpecificSpeeds), NBT::TAG_Compound));
     }
 }

--- a/src/Blocks/Components/FlammableBlockComponent.php
+++ b/src/Blocks/Components/FlammableBlockComponent.php
@@ -3,6 +3,7 @@
 namespace Nexly\Blocks\Components;
 
 use Attribute;
+use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
 
@@ -12,7 +13,11 @@ class FlammableBlockComponent extends BlockComponent
     public function __construct(
         private readonly int $catchChanceModifier = 5,
         private readonly int $destroyChanceModifier = 20,
+        private readonly bool $lavaFlammable = false,
     ) {
+        if ($catchChanceModifier < 0 || $destroyChanceModifier < 0) {
+            throw new \InvalidArgumentException("Flammability modifiers cannot be negative.");
+        }
     }
 
     /**
@@ -34,6 +39,7 @@ class FlammableBlockComponent extends BlockComponent
     {
         return CompoundTag::create()
             ->setTag("catch_chance_modifier", new IntTag($this->catchChanceModifier))
-            ->setTag("destroy_chance_modifier", new IntTag($this->destroyChanceModifier));
+            ->setTag("destroy_chance_modifier", new IntTag($this->destroyChanceModifier))
+            ->setTag("lava_flammable", new ByteTag($this->lavaFlammable ? 1 : 0));
     }
 }

--- a/src/Blocks/Components/GeometryBlockComponent.php
+++ b/src/Blocks/Components/GeometryBlockComponent.php
@@ -3,24 +3,34 @@
 namespace Nexly\Blocks\Components;
 
 use Attribute;
+use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\StringTag;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class GeometryBlockComponent extends BlockComponent
 {
+    /**
+     * @param bool|list<string> $uvLock
+     */
     public function __construct(
-        private readonly string $name = "minecraft:geometry.full_block",
+        private readonly string $identifier = "minecraft:geometry.full_block",
         private readonly string $culling = "",
-        private readonly string $culling_layer = "minecraft:culling_layer.undefined",
+        private readonly string $cullingLayer = "minecraft:culling_layer.undefined",
+        private readonly string $cullingShape = "minecraft:empty",
+        private readonly ?string $nWayVisualRotation = null,
+        private readonly bool|array $uvLock = false,
         private readonly bool $ignoreGeometryForIsSolid = true,
         private readonly bool $needsLegacyTopRotation = false,
         private readonly bool $useBlockTypeLightAbsorption = false,
-        private readonly bool $uv_lock = false,
-        private ?CompoundTag    $boneVisibility = null
+        private ?CompoundTag $boneVisibility = null
     ) {
         $this->boneVisibility ??= CompoundTag::create();
+        if (is_array($uvLock) && count($uvLock) > 64) {
+            throw new \InvalidArgumentException("UV lock cannot contain more than 64 bone names.");
+        }
     }
 
     /**
@@ -43,7 +53,7 @@ class GeometryBlockComponent extends BlockComponent
         $this->boneVisibility->setTag(
             $boneName,
             is_bool($visibility) ?
-            new ByteTag($visibility) : CompoundTag::create()
+            new ByteTag($visibility ? 1 : 0) : CompoundTag::create()
                 ->setString("expression", $visibility)
                 ->setShort("version", 12)
         );
@@ -57,14 +67,26 @@ class GeometryBlockComponent extends BlockComponent
      */
     public function toNBT(): CompoundTag
     {
-        return CompoundTag::create()
+        $nbt = CompoundTag::create()
             ->setTag("bone_visibility", $this->boneVisibility)
-            ->setTag("identifier", new StringTag($this->name))
-            ->setTag("culling", new StringTag(""))
-            ->setTag("culling_layer", new StringTag($this->culling_layer))
-            ->setTag("ignoreGeometryForIsSolid", new ByteTag($this->ignoreGeometryForIsSolid))
-            ->setTag("needsLegacyTopRotation", new ByteTag($this->needsLegacyTopRotation))
-            ->setTag("useBlockTypeLightAbsorption", new ByteTag($this->useBlockTypeLightAbsorption))
-            ->setTag("uv_lock", new ByteTag($this->uv_lock));
+            ->setTag("identifier", new StringTag($this->identifier))
+            ->setTag("culling", new StringTag($this->culling))
+            ->setTag("culling_layer", new StringTag($this->cullingLayer))
+            ->setTag("ignoreGeometryForIsSolid", new ByteTag($this->ignoreGeometryForIsSolid ? 1 : 0))
+            ->setTag("needsLegacyTopRotation", new ByteTag($this->needsLegacyTopRotation ? 1 : 0))
+            ->setTag("useBlockTypeLightAbsorption", new ByteTag($this->useBlockTypeLightAbsorption ? 1 : 0));
+
+        $nbt->setTag("culling_shape", new StringTag($this->cullingShape));
+
+        if ($this->nWayVisualRotation !== null) {
+            $nbt->setTag("n_way_visual_rotation", new StringTag($this->nWayVisualRotation));
+        }
+
+        $nbt->setTag("uv_lock", is_bool($this->uvLock)
+            ? new ByteTag($this->uvLock ? 1 : 0)
+            : new ListTag(array_map(fn (string $bone): StringTag => new StringTag($bone), $this->uvLock), NBT::TAG_String)
+        );
+
+        return $nbt;
     }
 }

--- a/src/Blocks/Components/LightEmissionBlockComponent.php
+++ b/src/Blocks/Components/LightEmissionBlockComponent.php
@@ -13,7 +13,7 @@ class LightEmissionBlockComponent extends BlockComponent
         private readonly int $value,
     ) {
         if ($value < 0 || $value > 15) {
-            throw new \InvalidArgumentException("Light dampening value must be between 0 and 15");
+            throw new \InvalidArgumentException("Light emission value must be between 0 and 15");
         }
     }
 

--- a/src/Blocks/Components/LiquidDetectionComponent.php
+++ b/src/Blocks/Components/LiquidDetectionComponent.php
@@ -12,10 +12,10 @@ use pocketmine\nbt\tag\ListTag;
 class LiquidDetectionComponent extends BlockComponent
 {
     /**
-     * @param LiquidRule[] $rules
+     * @param list<LiquidRule> $rules
      */
     public function __construct(
-        private array $rules,
+        private readonly array $rules = [],
     ) {
     }
 
@@ -37,6 +37,6 @@ class LiquidDetectionComponent extends BlockComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("detectionRules", new ListTag(array_map(fn (LiquidRule $rule) => $rule->toNBT(), $this->rules), NBT::TAG_Compound));
+            ->setTag("detectionRules", new ListTag(array_map(fn (LiquidRule $rule): CompoundTag => $rule->toNBT(), $this->rules), NBT::TAG_Compound));
     }
 }

--- a/src/Blocks/Components/PlacementFilterBlockComponent.php
+++ b/src/Blocks/Components/PlacementFilterBlockComponent.php
@@ -5,11 +5,17 @@ namespace Nexly\Blocks\Components;
 use Attribute;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ListTag;
+use pocketmine\nbt\tag\StringTag;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class PlacementFilterBlockComponent extends BlockComponent
 {
+    /**
+     * @param list<IntTag> $allowedFaces
+     * @param list<StringTag> $blockFilter
+     */
     public function __construct(
         private readonly array $allowedFaces = [],
         private readonly array $blockFilter = [],

--- a/src/Blocks/Components/PrecipitationInteractionsBlockComponent.php
+++ b/src/Blocks/Components/PrecipitationInteractionsBlockComponent.php
@@ -11,7 +11,7 @@ use pocketmine\nbt\tag\StringTag;
 class PrecipitationInteractionsBlockComponent extends BlockComponent
 {
     public function __construct(
-        private readonly PrecipitationType $precipitation,
+        private readonly PrecipitationType $precipitationBehavior,
     ) {
     }
 
@@ -31,6 +31,6 @@ class PrecipitationInteractionsBlockComponent extends BlockComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("precipitation_behavior", new StringTag(strtolower($this->precipitation->getName())));
+            ->setTag("precipitation_behavior", new StringTag($this->precipitationBehavior->getValue()));
     }
 }

--- a/src/Blocks/Components/SelectionBoxBlockComponent.php
+++ b/src/Blocks/Components/SelectionBoxBlockComponent.php
@@ -7,6 +7,7 @@ use Nexly\Blocks\Components\Types\BoxCollision;
 use pocketmine\block\Beetroot;
 use pocketmine\block\Block;
 use pocketmine\block\Carrot;
+use pocketmine\block\Crops;
 use pocketmine\block\NetherWartPlant;
 use pocketmine\block\Potato;
 use pocketmine\math\Vector3;
@@ -33,10 +34,10 @@ class SelectionBoxBlockComponent extends BlockComponent
      * Creates the component from a Block instance.
      *
      * @param int $age
-     * @param Block $block
+     * @param Crops|NetherWartPlant $block
      * @return self
      */
-    public static function fromCrops(Block $block, int $age): self
+    public static function fromCrops(Crops|NetherWartPlant $block, int $age): self
     {
         return new self(
             true,
@@ -47,7 +48,7 @@ class SelectionBoxBlockComponent extends BlockComponent
                         $block instanceof Carrot => new Vector3(16.0, (($age + 1.0) * (1 / $block::MAX_AGE)) * 0.7 * 16, 16.0),
                         $block instanceof Potato, $block instanceof Beetroot => new Vector3(16.0, (($age + 1.0) * (1 / $block::MAX_AGE)) * 0.6 * 16, 16.0),
                         $block instanceof NetherWartPlant => new Vector3(16.0, ($age + 1.0) * 0.25 * 16, 16.0),
-                        default => new Vector3(16.0, ($age + 1) * (1 / ($block::MAX_AGE ?? 7)) * 16, 16.0),
+                        default => new Vector3(16.0, ($age + 1) * (1 / $block::MAX_AGE) * 16, 16.0),
                     }
                 )
             ]
@@ -72,11 +73,9 @@ class SelectionBoxBlockComponent extends BlockComponent
     public function toNBT(): CompoundTag
     {
         if (!$this->enabled) {
-            return CompoundTag::create()
-                ->setTag("enabled", new ByteTag($this->enabled));
+            return CompoundTag::create()->setTag("enabled", new ByteTag(0));
         }
 
-        return $this->collisions[array_key_first($this->collisions)]->toNBT(false)
-            ->setTag("enabled", new ByteTag($this->enabled));
+        return $this->collisions[array_key_first($this->collisions)]->toNBT(false)->setTag("enabled", new ByteTag(1));
     }
 }

--- a/src/Blocks/Components/TransformationBlockComponent.php
+++ b/src/Blocks/Components/TransformationBlockComponent.php
@@ -16,9 +16,15 @@ class TransformationBlockComponent extends BlockComponent
         private readonly Vector3 $rotation = new Vector3(0, 0, 0),
         private readonly Vector3 $scale = new Vector3(1, 1, 1),
         private readonly Vector3 $translation = new Vector3(0, 0, 0),
+        private readonly Vector3 $rotationPivot = new Vector3(0, 0, 0),
+        private readonly Vector3 $scalePivot = new Vector3(0, 0, 0),
         private readonly bool $hasJsonVersionBeforeValidation = false,
     ) {
-
+        foreach ([$rotation->getX(), $rotation->getY(), $rotation->getZ()] as $angle) {
+            if (abs(fmod((float) $angle, 90.0)) > PHP_FLOAT_EPSILON) {
+                throw new \InvalidArgumentException("Block rotation values must be multiples of 90 degrees.");
+            }
+        }
     }
 
     /**
@@ -48,6 +54,12 @@ class TransformationBlockComponent extends BlockComponent
             ->setTag("TX", new FloatTag($this->translation->getX()))
             ->setTag("TY", new FloatTag($this->translation->getY()))
             ->setTag("TZ", new FloatTag($this->translation->getZ()))
-            ->setTag("hasJsonVersionBeforeValidation", new ByteTag($this->hasJsonVersionBeforeValidation));
+            ->setTag("RPX", new FloatTag($this->rotationPivot->getX()))
+            ->setTag("RPY", new FloatTag($this->rotationPivot->getY()))
+            ->setTag("RPZ", new FloatTag($this->rotationPivot->getZ()))
+            ->setTag("SPX", new FloatTag($this->scalePivot->getX()))
+            ->setTag("SPY", new FloatTag($this->scalePivot->getY()))
+            ->setTag("SPZ", new FloatTag($this->scalePivot->getZ()))
+            ->setTag("hasJsonVersionBeforeValidation", new ByteTag($this->hasJsonVersionBeforeValidation ? 1 : 0));
     }
 }

--- a/src/Blocks/Components/Types/BoxCollision.php
+++ b/src/Blocks/Components/Types/BoxCollision.php
@@ -48,6 +48,7 @@ class BoxCollision
         private Vector3 $origin,
         private Vector3 $size,
     ) {
+        self::validate($origin, $size);
     }
 
     /**
@@ -63,6 +64,7 @@ class BoxCollision
      */
     public function setOrigin(Vector3 $origin): void
     {
+        self::validate($origin, $this->size);
         $this->origin = $origin;
     }
 
@@ -79,7 +81,28 @@ class BoxCollision
      */
     public function setSize(Vector3 $size): void
     {
+        self::validate($this->origin, $size);
         $this->size = $size;
+    }
+
+    private static function validate(Vector3 $origin, Vector3 $size): void
+    {
+        if (
+            $origin->getX() < -8 || $origin->getX() > 8
+            || $origin->getY() < 0 || $origin->getY() > 24
+            || $origin->getZ() < -8 || $origin->getZ() > 8
+        ) {
+            throw new \InvalidArgumentException("Collision-box origin is outside the supported Bedrock range.");
+        }
+
+        if (
+            $size->getX() < 0 || $size->getY() < 0 || $size->getZ() < 0
+            || $origin->getX() + $size->getX() > 8
+            || $origin->getY() + $size->getY() > 24
+            || $origin->getZ() + $size->getZ() > 8
+        ) {
+            throw new \InvalidArgumentException("Collision-box size exceeds the supported Bedrock bounds.");
+        }
     }
 
     /**
@@ -105,16 +128,8 @@ class BoxCollision
         }
 
         return CompoundTag::create()
-            ->setTag("origin", new ListTag([
-                new FloatTag($this->origin->getX()),
-                new FloatTag($this->origin->getY()),
-                new FloatTag($this->origin->getZ())
-            ], NBT::TAG_Float))
-            ->setTag("size", new ListTag([
-                new FloatTag($this->size->getX()),
-                new FloatTag($this->size->getY()),
-                new FloatTag($this->size->getZ())
-            ], NBT::TAG_Float));
+            ->setTag("origin", new ListTag([new FloatTag($this->origin->getX()), new FloatTag($this->origin->getY()), new FloatTag($this->origin->getZ())], NBT::TAG_Float))
+            ->setTag("size", new ListTag([new FloatTag($this->size->getX()), new FloatTag($this->size->getY()), new FloatTag($this->size->getZ())], NBT::TAG_Float));
     }
 }
 BoxCollision::checkInit();

--- a/src/Blocks/Components/Types/ConnectionType.php
+++ b/src/Blocks/Components/Types/ConnectionType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Nexly\Blocks\Components\Types;
+
+enum ConnectionType: string
+{
+    case ALL = "all";
+    case NONE = "none";
+    case ONLY_FENCES = "only_fences";
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Blocks/Components/Types/HorizontalFace.php
+++ b/src/Blocks/Components/Types/HorizontalFace.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Nexly\Blocks\Components\Types;
+
+enum HorizontalFace: string
+{
+    case NORTH = "north";
+    case SOUTH = "south";
+    case EAST = "east";
+    case WEST = "west";
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Blocks/Components/Types/ItemDescriptor.php
+++ b/src/Blocks/Components/Types/ItemDescriptor.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Nexly\Blocks\Components\Types;
+
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\StringTag;
+
+readonly class ItemDescriptor
+{
+    private function __construct(
+        private string $tags,
+    ) {
+        if ($tags === "") {
+            throw new \InvalidArgumentException("Item descriptor tags cannot be empty.");
+        }
+    }
+
+    public static function fromTags(string $molangQuery): self
+    {
+        return new self($molangQuery);
+    }
+
+    public function toNBT(): CompoundTag
+    {
+        return CompoundTag::create()
+            ->setTag("tags", new StringTag($this->tags));
+    }
+}

--- a/src/Blocks/Components/Types/ItemSpecificSpeed.php
+++ b/src/Blocks/Components/Types/ItemSpecificSpeed.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Nexly\Blocks\Components\Types;
+
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\FloatTag;
+use pocketmine\nbt\tag\StringTag;
+
+readonly class ItemSpecificSpeed
+{
+    public function __construct(
+        private string|ItemDescriptor $item,
+        private float $destroySpeed,
+    ) {
+        if ($item === "") {
+            throw new \InvalidArgumentException("Item identifier cannot be empty.");
+        }
+
+        if ($destroySpeed < 0.0) {
+            throw new \InvalidArgumentException("Item-specific destroy speed cannot be negative.");
+        }
+    }
+
+    public function toNBT(): CompoundTag
+    {
+        return CompoundTag::create()
+            ->setTag("item", is_string($this->item) ? new StringTag($this->item) : $this->item->toNBT())
+            ->setTag("destroy_speed", new FloatTag($this->destroySpeed));
+    }
+}

--- a/src/Blocks/Components/Types/LiquidRule.php
+++ b/src/Blocks/Components/Types/LiquidRule.php
@@ -2,18 +2,30 @@
 
 namespace Nexly\Blocks\Components\Types;
 
+use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\StringTag;
 
 readonly class LiquidRule
 {
+    /**
+     * @param list<string> $stopsLiquidFlowingFromDirection
+     */
     public function __construct(
         private bool              $canContainLiquid,
         private LiquidType        $liquidType = LiquidType::WATER,
-        private LiquidTouchAction $onLiquidTouches = LiquidTouchAction::NO_REACTION,
-        private bool              $stopsLiquidFromDirection = false,
+        private LiquidTouchAction $onLiquidTouches = LiquidTouchAction::BLOCKING,
+        private array             $stopsLiquidFlowingFromDirection = [],
+        private bool              $useLiquidClipping = false,
     ) {
+        $validDirections = ["down", "up", "north", "south", "east", "west"];
+        foreach ($stopsLiquidFlowingFromDirection as $direction) {
+            if (!in_array($direction, $validDirections, true)) {
+                throw new \InvalidArgumentException("Invalid stopped liquid-flow direction: $direction");
+            }
+        }
     }
 
     /**
@@ -41,11 +53,11 @@ readonly class LiquidRule
     }
 
     /**
-     * @return bool
+     * @return list<string>
      */
-    public function stopsLiquidFromDirection(): bool
+    public function stopsLiquidFromDirection(): array
     {
-        return $this->stopsLiquidFromDirection;
+        return $this->stopsLiquidFlowingFromDirection;
     }
 
     /**
@@ -54,9 +66,10 @@ readonly class LiquidRule
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("canContainLiquid", new ByteTag($this->canContainLiquid))
+            ->setTag("canContainLiquid", new ByteTag($this->canContainLiquid ? 1 : 0))
             ->setTag("liquidType", new StringTag($this->liquidType->getValue()))
             ->setTag("onLiquidTouches", new StringTag($this->onLiquidTouches->getValue()))
-            ->setTag("stopsLiquidFromDirection", new ByteTag($this->stopsLiquidFromDirection));
+            ->setTag("stopsLiquidFromDirection", new ListTag(array_map(fn (string $direction): StringTag => new StringTag($direction), $this->stopsLiquidFlowingFromDirection), NBT::TAG_String))
+            ->setTag("useLiquidClipping", new ByteTag($this->useLiquidClipping ? 1 : 0));
     }
 }

--- a/src/Blocks/Components/Types/LiquidTouchAction.php
+++ b/src/Blocks/Components/Types/LiquidTouchAction.php
@@ -33,7 +33,7 @@ enum LiquidTouchAction: string
      * Creates a LiquidType from a string value.
      *
      * @param string $value
-     * @return LiquidType|null
+     * @return self|null
      */
     public static function fromString(string $value): ?self
     {

--- a/src/Blocks/Components/Types/LiquidType.php
+++ b/src/Blocks/Components/Types/LiquidType.php
@@ -5,7 +5,6 @@ namespace Nexly\Blocks\Components\Types;
 enum LiquidType: string
 {
     case WATER = "water";
-    case LAVA = "lava";
 
     /**
      * Returns the name of the liquid type.
@@ -37,7 +36,6 @@ enum LiquidType: string
     {
         return match ($value) {
             self::WATER->value => self::WATER,
-            self::LAVA->value => self::LAVA,
             default => null,
         };
     }

--- a/src/Blocks/Components/Types/Material.php
+++ b/src/Blocks/Components/Types/Material.php
@@ -15,11 +15,15 @@ final class Material
         private readonly string               $texture,
         private readonly MaterialTarget       $target = MaterialTarget::ALL,
         private readonly MaterialRenderMethod $renderMethod = MaterialRenderMethod::OPAQUE,
-        private readonly string               $tint_method = "none",
+        private readonly string               $tintMethod = "none",
         private readonly float                $ambientOcclusion = 1.0,
         private readonly bool                 $faceDimming = true,
+        private readonly bool                 $isotropic = false,
         private readonly bool                 $packedBools = false,
     ) {
+        if ($ambientOcclusion < 0.0) {
+            throw new \InvalidArgumentException("Ambient occlusion cannot be negative.");
+        }
     }
 
     /**
@@ -41,6 +45,7 @@ final class Material
             ->setTag("render_method", new StringTag($this->renderMethod->getValue()))
             ->setTag("texture", new StringTag($this->texture))
             ->setTag("face_dimming", new ByteTag($this->faceDimming ? 1 : 0))
-            ->setTag("tint_method", new StringTag($this->tint_method));
+            ->setTag("isotropic", new ByteTag($this->isotropic ? 1 : 0))
+            ->setTag("tint_method", new StringTag($this->tintMethod));
     }
 }

--- a/src/Blocks/Components/Types/MinecraftGeometry.php
+++ b/src/Blocks/Components/Types/MinecraftGeometry.php
@@ -5,6 +5,8 @@ namespace Nexly\Blocks\Components\Types;
 enum MinecraftGeometry: string
 {
     case FULL_BLOCK = "minecraft:geometry.full_block";
+    case FULL_BLOCK_V1 = "minecraft:geometry.full_block_v1";
+    case FULL_CUBE = "minecraft:geometry.full_cube";
     case CROSS = "minecraft:geometry.cross";
     case BEACON = "minecraft:geometry.beacon";
     case BIG_DRIPLEAF = "minecraft:geometry.big_dripleaf";

--- a/src/Blocks/Components/Types/PrecipitationType.php
+++ b/src/Blocks/Components/Types/PrecipitationType.php
@@ -2,12 +2,12 @@
 
 namespace Nexly\Blocks\Components\Types;
 
-enum PrecipitationType
+enum PrecipitationType: string
 {
-    case OBRAIN;
-    case OBSTRUCT_RAIN_ACCUMULATE_SNOW;
-    case ACCUMULATE_SNOW;
-    case NONE;
+    case OBSTRUCT_RAIN = "obstruct_rain";
+    case OBSTRUCT_RAIN_ACCUMULATE_SNOW = "obstruct_rain_accumulate_snow";
+    case SNOWLOGGING = "snowlogging";
+    case NONE = "none";
 
     /**
      * @return string
@@ -15,5 +15,10 @@ enum PrecipitationType
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
     }
 }

--- a/src/Blocks/Permutations/BlockProperty.php
+++ b/src/Blocks/Permutations/BlockProperty.php
@@ -10,14 +10,22 @@ use pocketmine\nbt\tag\StringTag;
 
 class BlockProperty
 {
+    /** @var non-empty-list<string|int|bool> */
+    private readonly array $values;
+
     /**
      * @param string $name
-     * @param array $values
+     * @param list<string|int|bool> $values
      */
     public function __construct(
         private readonly string $name,
-        private readonly array $values
+        array $values
     ) {
+        if ($values === []) {
+            throw new \InvalidArgumentException("A block property must define at least one possible value.");
+        }
+
+        $this->values = $values;
     }
 
     /**
@@ -29,23 +37,25 @@ class BlockProperty
     }
 
     /**
-     * @return array
+     * @return non-empty-list<string|int|bool>
      */
     public function getValues(): array
     {
         return $this->values;
     }
 
-    public function toNBT()
+    public function toNBT(): CompoundTag
     {
+        /** @var list<StringTag|IntTag|ByteTag> $values */
         $values = [];
         foreach ($this->values as $value) {
-            $values[] = match (true) {
-                is_string($value) => new StringTag($value),
-                is_int($value) => new IntTag($value),
-                is_bool($value) => new ByteTag($value),
-                default => throw new \InvalidArgumentException("Invalid value type for BlockProperty: " . gettype($value)),
-            };
+            if (is_string($value)) {
+                $values[] = new StringTag($value);
+            } elseif (is_int($value)) {
+                $values[] = new IntTag($value);
+            } else {
+                $values[] = new ByteTag($value ? 1 : 0);
+            }
         }
 
         return CompoundTag::create()

--- a/src/Blocks/Permutations/CartesianProduct.php
+++ b/src/Blocks/Permutations/CartesianProduct.php
@@ -7,14 +7,18 @@ class CartesianProduct
     /**
      * Returns an 2-dimensional array containing all possible combinations of the provided arrays using the cartesian
      * product (https://en.wikipedia.org/wiki/Cartesian_product).
+     *
+     * @template T
+     * @param list<non-empty-list<T>> $arrays
+     * @return list<list<T>>
      */
     public static function get(array $arrays): array
     {
         $result = [];
         $count = count($arrays) - 1;
-        $combinations = array_product(array_map(static fn (array $array) => count($array), $arrays));
+        $combinations = array_product(array_map(static fn (array $array): int => count($array), $arrays));
         for ($i = 0; $i < $combinations; $i++) {
-            $result[] = array_map(static fn (array $array) => current($array), $arrays);
+            $result[] = array_map(static fn (array $array): mixed => current($array), $arrays);
             for ($j = $count; $j >= 0; $j--) {
                 if (next($arrays[$j])) {
                     break;

--- a/src/Blocks/Permutations/Impl/WallPermutation.php
+++ b/src/Blocks/Permutations/Impl/WallPermutation.php
@@ -59,8 +59,8 @@ class WallPermutation
         )->addPermutation(
             Permutation::create()
             ->setCondition("q.block_state('" . StateNames::WALL_CONNECTION_TYPE_NORTH . "') == 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_SOUTH . "') == 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_WEST . "') == 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_EAST . "') != 0")
-            ->addComponent(new CollisionBoxBlockComponent(true, [new BoxCollision(new Vector3(-9, 0, -4), new Vector3(13, 24, 8))]))
-            ->addComponent(new SelectionBoxBlockComponent(true, [new BoxCollision(new Vector3(-9, 0, -4), new Vector3(13, 13, 8))]))
+            ->addComponent(new CollisionBoxBlockComponent(true, [new BoxCollision(new Vector3(-8, 0, -4), new Vector3(12, 24, 8))]))
+            ->addComponent(new SelectionBoxBlockComponent(true, [new BoxCollision(new Vector3(-8, 0, -4), new Vector3(12, 13, 8))]))
         )->addPermutation(
             Permutation::create()
             ->setCondition("q.block_state('" . StateNames::WALL_CONNECTION_TYPE_NORTH . "') != 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_SOUTH . "') != 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_WEST . "') == 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_EAST . "') == 0")
@@ -74,8 +74,8 @@ class WallPermutation
         )->addPermutation(
             Permutation::create()
             ->setCondition("q.block_state('" . StateNames::WALL_CONNECTION_TYPE_NORTH . "') != 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_SOUTH . "') == 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_WEST . "') != 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_EAST . "') == 0")
-            ->addComponent(new CollisionBoxBlockComponent(true, [new BoxCollision(new Vector3(-4, 0, -9), new Vector3(16, 24, 13))]))
-            ->addComponent(new SelectionBoxBlockComponent(true, [new BoxCollision(new Vector3(-4, 0, -9), new Vector3(16, 13, 13))]))
+            ->addComponent(new CollisionBoxBlockComponent(true, [new BoxCollision(new Vector3(-4, 0, -8), new Vector3(12, 24, 12))]))
+            ->addComponent(new SelectionBoxBlockComponent(true, [new BoxCollision(new Vector3(-4, 0, -8), new Vector3(12, 13, 12))]))
         )->addPermutation(
             Permutation::create()
             ->setCondition("q.block_state('" . StateNames::WALL_CONNECTION_TYPE_NORTH . "') != 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_SOUTH . "') == 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_WEST . "') == 0 && q.block_state('" . StateNames::WALL_CONNECTION_TYPE_EAST . "') != 0")

--- a/src/Blocks/Permutations/NexlyPermutations.php
+++ b/src/Blocks/Permutations/NexlyPermutations.php
@@ -71,8 +71,8 @@ final class NexlyPermutations
     public static function makeCrop(Builder $builder, Crops $block): void
     {
         $stringId = $builder->getStringId();
-        $builder->setSerializer(static fn (Crops $block) => SerializerHelper::encodeCrops($block, new Writer($stringId)));
-        $builder->setDeserializer(static fn (Reader $in) => DeserializerHelper::decodeCrops(clone $block, $in));
+        $builder->setSerializer(static fn (Crops $block): Writer => SerializerHelper::encodeCrops($block, new Writer($stringId)));
+        $builder->setDeserializer(static fn (Reader $in): Crops => DeserializerHelper::decodeCrops(clone $block, $in));
         $builder->addProperty(new BlockProperty(StateNames::GROWTH, $ages = range(0, $block::MAX_AGE)));
         $builder->addComponent(new GeometryBlockComponent(ExtendedGeometry::CROP->toString()));
         foreach ($ages as $age) {
@@ -92,8 +92,8 @@ final class NexlyPermutations
     public static function makeNetherPlant(Builder $builder, NetherWartPlant $block): void
     {
         $stringId = $builder->getStringId();
-        $builder->setSerializer(static fn (NetherWartPlant $block) => (new Writer($stringId))->writeInt(StateNames::AGE, $block->getAge()));
-        $builder->setDeserializer(static fn (Reader $in) => (clone $block)->setAge($in->readBoundedInt(StateNames::AGE, 0, 3)));
+        $builder->setSerializer(static fn (NetherWartPlant $block): Writer => (new Writer($stringId))->writeInt(StateNames::AGE, $block->getAge()));
+        $builder->setDeserializer(static fn (Reader $in): NetherWartPlant => (clone $block)->setAge($in->readBoundedInt(StateNames::AGE, 0, 3)));
         $builder->addProperty(new BlockProperty(StateNames::AGE, $ages = range(0, $block::MAX_AGE)));
         $builder->addComponent(new GeometryBlockComponent(ExtendedGeometry::NETHER_WART->toString()));
         foreach ($ages as $age) {
@@ -113,13 +113,13 @@ final class NexlyPermutations
     public static function makeStair(Builder $builder, Stair $block): void
     {
         $stringId = $builder->getStringId();
-        $builder->setSerializer(static function (Stair $block) use ($stringId) {
+        $builder->setSerializer(static function (Stair $block) use ($stringId): Writer {
             return (new Writer($stringId))
                 ->writeBool(BlockStateNames::UPSIDE_DOWN_BIT, $block->isUpsideDown())
                 ->write5MinusHorizontalFacing($block->getFacing());
         });
         $builder->setDeserializer(
-            static fn (Reader $in) => (clone $block)
+            static fn (Reader $in): Stair => (clone $block)
             ->setUpsideDown($in->readBool(BlockStateNames::UPSIDE_DOWN_BIT))
             ->setFacing($in->read5MinusHorizontalFacing())
         );
@@ -170,13 +170,13 @@ final class NexlyPermutations
     public static function makeSlab(Builder $builder, Slab $block): void
     {
         $stringId = $builder->getStringId();
-        $builder->setSerializer(static fn (Slab $block) => (new Writer($stringId))->writeString(StateNames::MC_VERTICAL_HALF, match ($block->getSlabType()) {
+        $builder->setSerializer(static fn (Slab $block): Writer => (new Writer($stringId))->writeString(StateNames::MC_VERTICAL_HALF, match ($block->getSlabType()) {
             SlabType::BOTTOM => StateValues::MC_VERTICAL_HALF_BOTTOM,
             SlabType::TOP => StateValues::MC_VERTICAL_HALF_TOP,
             SlabType::DOUBLE => "double",
 
         }));
-        $builder->setDeserializer(static fn (Reader $in) => (clone $block)->setSlabType(match ($in->readString(StateNames::MC_VERTICAL_HALF)) {
+        $builder->setDeserializer(static fn (Reader $in): Slab => (clone $block)->setSlabType(match ($in->readString(StateNames::MC_VERTICAL_HALF)) {
             StateValues::MC_VERTICAL_HALF_BOTTOM => SlabType::BOTTOM,
             StateValues::MC_VERTICAL_HALF_TOP => SlabType::TOP,
             "double" => SlabType::DOUBLE,
@@ -217,8 +217,8 @@ final class NexlyPermutations
     public static function makeDoor(Builder $builder, Door $block): void
     {
         $stringId = $builder->getStringId();
-        $builder->setSerializer(static fn (Door $block) => SerializerHelper::encodeDoor($block, Writer::create($stringId)));
-        $builder->setDeserializer(static fn (Reader $in) => DeserializerHelper::decodeDoor(clone $block, $in));
+        $builder->setSerializer(static fn (Door $block): Writer => SerializerHelper::encodeDoor($block, Writer::create($stringId)));
+        $builder->setDeserializer(static fn (Reader $in): Door => DeserializerHelper::decodeDoor(clone $block, $in));
 
         $builder->addProperty(new BlockProperty(StateNames::MC_CARDINAL_DIRECTION, $facings = [
             StateValues::MC_CARDINAL_DIRECTION_NORTH,
@@ -257,7 +257,6 @@ final class NexlyPermutations
                         StateValues::MC_CARDINAL_DIRECTION_SOUTH => new Vector3(0, 180, 0),
                         StateValues::MC_CARDINAL_DIRECTION_WEST => new Vector3(0, 90, 0),
                         StateValues::MC_CARDINAL_DIRECTION_EAST => new Vector3(0, 270, 0),
-                        default => throw new RuntimeException("Invalid direction")
                     }));
 
                     $builder->addPermutation($permutation);
@@ -295,16 +294,16 @@ final class NexlyPermutations
             $co = [];
 
             if ($in->readBool("mc:n")) {
-                $co[Facing::NORTH] = Facing::NORTH;
+                $co[Facing::NORTH] = true;
             }
             if ($in->readBool("mc:s")) {
-                $co[Facing::SOUTH] = Facing::SOUTH;
+                $co[Facing::SOUTH] = true;
             }
             if ($in->readBool("mc:w")) {
-                $co[Facing::WEST] = Facing::WEST;
+                $co[Facing::WEST] = true;
             }
             if ($in->readBool("mc:e")) {
-                $co[Facing::EAST] = Facing::EAST;
+                $co[Facing::EAST] = true;
             }
 
             $reflection = new ReflectionClass(Fence::class);
@@ -342,7 +341,7 @@ final class NexlyPermutations
     {
         $stringId = $builder->getStringId();
         $builder->setSerializer(
-            static fn (FenceGate $block) => (new Writer($stringId))
+            static fn (FenceGate $block): Writer => (new Writer($stringId))
             ->writeString(StateNames::MC_CARDINAL_DIRECTION, match ($block->getFacing()) {
                 Facing::NORTH => StateValues::MC_CARDINAL_DIRECTION_NORTH,
                 Facing::SOUTH => StateValues::MC_CARDINAL_DIRECTION_SOUTH,
@@ -354,7 +353,7 @@ final class NexlyPermutations
             ->writeBool(StateNames::OPEN_BIT, $block->isOpen())
         );
         $builder->setDeserializer(
-            static fn (Reader $in) => (clone $block)
+            static fn (Reader $in): FenceGate => (clone $block)
             ->setFacing(match ($in->readString(StateNames::MC_CARDINAL_DIRECTION)) {
                 StateValues::MC_CARDINAL_DIRECTION_NORTH => Facing::NORTH,
                 StateValues::MC_CARDINAL_DIRECTION_SOUTH => Facing::SOUTH,
@@ -400,7 +399,6 @@ final class NexlyPermutations
                         StateValues::MC_CARDINAL_DIRECTION_SOUTH => new Vector3(0, 180, 0),
                         StateValues::MC_CARDINAL_DIRECTION_EAST => new Vector3(0, 270, 0),
                         StateValues::MC_CARDINAL_DIRECTION_WEST => new Vector3(0, 90, 0),
-                        default => throw new RuntimeException("Invalid direction")
                     }, translation: match ($inWall) {
                         0 => new Vector3(0, 0, 0),
                         1 => new Vector3(0, -0.187, 0),
@@ -423,9 +421,9 @@ final class NexlyPermutations
     {
         $stringId = $builder->getStringId();
         $builder->setSerializer(
-            static fn (Wall $block) => (new Writer($stringId))
-            ->writeInt(StateNames::WALL_POST_BIT, $block->isPost())
-            ->writeInt(StateNames::WALL_CONNECTION_TYPE_NORTH, ($encode = static fn (WallConnectionType|null $v) => match ($v) {
+            static fn (Wall $block): Writer => (new Writer($stringId))
+            ->writeInt(StateNames::WALL_POST_BIT, $block->isPost() ? 1 : 0)
+            ->writeInt(StateNames::WALL_CONNECTION_TYPE_NORTH, ($encode = static fn (WallConnectionType|null $v): int => match ($v) {
                 default => 0,
                 WallConnectionType::SHORT => 1,
                 WallConnectionType::TALL => 2,
@@ -435,9 +433,9 @@ final class NexlyPermutations
             ->writeInt(StateNames::WALL_CONNECTION_TYPE_EAST, $encode($block->getConnection(Facing::EAST)))
         );
         $builder->setDeserializer(
-            static fn (Reader $in) => (clone $block)
-            ->setPost($in->readInt(StateNames::WALL_POST_BIT))
-            ->setConnection(Facing::NORTH, ($decode = static fn (int $v) => match ($v) {
+            static fn (Reader $in): Wall => (clone $block)
+            ->setPost($in->readInt(StateNames::WALL_POST_BIT) !== 0)
+            ->setConnection(Facing::NORTH, ($decode = static fn (int $v): ?WallConnectionType => match ($v) {
                 1 => WallConnectionType::SHORT,
                 2 => WallConnectionType::TALL,
                 default => null,
@@ -481,16 +479,16 @@ final class NexlyPermutations
     {
         $stringId = $builder->getStringId();
         $builder->setSerializer(
-            static fn (Trapdoor $block) => (new Writer($stringId))
+            static fn (Trapdoor $block): Writer => (new Writer($stringId))
             ->write5MinusHorizontalFacing($block->getFacing())
-            ->writeInt(StateNames::UPSIDE_DOWN_BIT, $block->isTop())
-            ->writeInt(StateNames::OPEN_BIT, $block->isOpen())
+            ->writeInt(StateNames::UPSIDE_DOWN_BIT, $block->isTop() ? 1 : 0)
+            ->writeInt(StateNames::OPEN_BIT, $block->isOpen() ? 1 : 0)
         );
         $builder->setDeserializer(
-            static fn (Reader $in) => (clone $block)
+            static fn (Reader $in): Trapdoor => (clone $block)
             ->setFacing($in->read5MinusHorizontalFacing())
-            ->setTop($in->readInt(StateNames::UPSIDE_DOWN_BIT))
-            ->setOpen($in->readInt(StateNames::OPEN_BIT))
+            ->setTop($in->readInt(StateNames::UPSIDE_DOWN_BIT) !== 0)
+            ->setOpen($in->readInt(StateNames::OPEN_BIT) !== 0)
         );
 
         $builder->addProperty(new BlockProperty(StateNames::DIRECTION, $facings = [0, 1, 2, 3])); // 0: East, 1: West, 2: South, 3: North
@@ -532,7 +530,6 @@ final class NexlyPermutations
                             1 => new Vector3(0, 0, 0),  // West
                             2 => new Vector3(0, 90, 0),   // South
                             3 => new Vector3(0, 270, 0),  // North
-                            default => throw new RuntimeException("Invalid direction")
                         }, translation: $translation));
 
                     $builder->addPermutation($permutation);
@@ -552,13 +549,13 @@ final class NexlyPermutations
     {
         $stringId = $builder->getStringId();
         $builder->setSerializer(
-            static fn (Hopper $block) => (new Writer($stringId))
-            ->writeInt(StateNames::TOGGLE_BIT, $block->isPowered())
+            static fn (Hopper $block): Writer => (new Writer($stringId))
+            ->writeInt(StateNames::TOGGLE_BIT, $block->isPowered() ? 1 : 0)
             ->writeFacingWithoutUp($block->getFacing())
         );
         $builder->setDeserializer(
-            static fn (Reader $in) => (clone $block)
-            ->setPowered($in->readInt(StateNames::TOGGLE_BIT))
+            static fn (Reader $in): Hopper => (clone $block)
+            ->setPowered($in->readInt(StateNames::TOGGLE_BIT) !== 0)
             ->setFacing($in->readFacingWithoutUp())
         );
 
@@ -643,8 +640,8 @@ final class NexlyPermutations
     public static function makeLadder(Builder $builder, Ladder $block): void
     {
         $stringId = $builder->getStringId();
-        $builder->setSerializer(static fn (Ladder $b) => (new Writer($stringId))->writeHorizontalFacing($b->getFacing()));
-        $builder->setDeserializer(static fn (Reader $in) => (clone $block)->setFacing($in->readHorizontalFacing()));
+        $builder->setSerializer(static fn (Ladder $b): Writer => (new Writer($stringId))->writeHorizontalFacing($b->getFacing()));
+        $builder->setDeserializer(static fn (Reader $in): Ladder => (clone $block)->setFacing($in->readHorizontalFacing()));
 
         $builder->addProperty(new BlockProperty(StateNames::FACING_DIRECTION, $facings = range(2, 5)));
         $builder->addComponent(new GeometryBlockComponent(ExtendedGeometry::LADDER->toString()));
@@ -659,7 +656,6 @@ final class NexlyPermutations
                     3 => new Vector3(0, 180, 0),
                     4 => new Vector3(0, 90, 0),
                     5 => new Vector3(0, 270, 0),
-                    default => throw new RuntimeException("Invalid direction")
                 }))
             );
         }
@@ -675,8 +671,8 @@ final class NexlyPermutations
     public static function makeFarmland(Builder $builder, Farmland $block): void
     {
         $stringId = $builder->getStringId();
-        $builder->setSerializer(static fn (Farmland $b) => (new Writer($stringId))->writeInt(StateNames::MOISTURIZED_AMOUNT, $b->getWetness()));
-        $builder->setDeserializer(static fn (Reader $in) => (clone $block)->setWetness($in->readInt(StateNames::MOISTURIZED_AMOUNT)));
+        $builder->setSerializer(static fn (Farmland $b): Writer => (new Writer($stringId))->writeInt(StateNames::MOISTURIZED_AMOUNT, $b->getWetness()));
+        $builder->setDeserializer(static fn (Reader $in): Farmland => (clone $block)->setWetness($in->readInt(StateNames::MOISTURIZED_AMOUNT)));
 
         $builder->addProperty(new BlockProperty(StateNames::MOISTURIZED_AMOUNT, range(0, Farmland::MAX_WETNESS)));
 
@@ -738,26 +734,26 @@ final class NexlyPermutations
             $connections = $reflection->getProperty("connections");
             $co = $connections->getValue($block);
             return (new Writer($stringId))
-                ->writeInt("mc:n", isset($co[Facing::NORTH]))
-                ->writeInt("mc:s", isset($co[Facing::SOUTH]))
-                ->writeInt("mc:w", isset($co[Facing::WEST]))
-                ->writeInt("mc:e", isset($co[Facing::EAST]));
+                ->writeInt("mc:n", isset($co[Facing::NORTH]) ? 1 : 0)
+                ->writeInt("mc:s", isset($co[Facing::SOUTH]) ? 1 : 0)
+                ->writeInt("mc:w", isset($co[Facing::WEST]) ? 1 : 0)
+                ->writeInt("mc:e", isset($co[Facing::EAST]) ? 1 : 0);
         });
         $builder->setDeserializer(static function (Reader $in) use ($block): GlassPane {
             $cloned = clone $block;
             $co = [];
 
             if ($in->readInt("mc:n")) {
-                $co[Facing::NORTH] = Facing::NORTH;
+                $co[Facing::NORTH] = true;
             }
             if ($in->readInt("mc:s")) {
-                $co[Facing::SOUTH] = Facing::SOUTH;
+                $co[Facing::SOUTH] = true;
             }
             if ($in->readInt("mc:w")) {
-                $co[Facing::WEST] = Facing::WEST;
+                $co[Facing::WEST] = true;
             }
             if ($in->readInt("mc:e")) {
-                $co[Facing::EAST] = Facing::EAST;
+                $co[Facing::EAST] = true;
             }
 
             $reflection = new ReflectionClass(GlassPane::class);
@@ -798,7 +794,7 @@ final class NexlyPermutations
     {
         $stringId = $builder->getStringId();
         $builder->setSerializer(
-            static fn (Lever $block) => Writer::create($stringId)
+            static fn (Lever $block): Writer => Writer::create($stringId)
             ->writeBool(StateNames::OPEN_BIT, $block->isActivated())
             ->writeString(StateNames::LEVER_DIRECTION, match($block->getFacing()) {
                 LeverFacing::DOWN_AXIS_Z => StateValues::LEVER_DIRECTION_DOWN_NORTH_SOUTH,
@@ -812,7 +808,7 @@ final class NexlyPermutations
             })
         );
         $builder->setDeserializer(
-            static fn (Reader $in) => (clone $block)
+            static fn (Reader $in): Lever => (clone $block)
             ->setActivated($in->readBool(StateNames::OPEN_BIT))
             ->setFacing(match($in->readString(StateNames::LEVER_DIRECTION)) {
                 StateValues::LEVER_DIRECTION_DOWN_NORTH_SOUTH => LeverFacing::DOWN_AXIS_Z,
@@ -856,7 +852,7 @@ final class NexlyPermutations
                     StateValues::LEVER_DIRECTION_UP_EAST_WEST,
                     StateValues::LEVER_DIRECTION_DOWN_NORTH_SOUTH,
                     StateValues::LEVER_DIRECTION_DOWN_EAST_WEST
-                ])) {
+                ], true)) {
                     $builder->addComponent(new SelectionBoxBlockComponent(true, [new BoxCollision(new Vector3(-4.0, 0.0, -4.0), new Vector3(8.0, 10.0, 8.0))]));
                 } else {
                     $builder->addComponent(new SelectionBoxBlockComponent(true, [new BoxCollision(new Vector3(-3.0, 0.0, -4.0), new Vector3(6.0, 6.0, 8.0))]));
@@ -873,7 +869,6 @@ final class NexlyPermutations
                         StateValues::LEVER_DIRECTION_SOUTH => new Vector3(90, 0, 0),
                         StateValues::LEVER_DIRECTION_EAST => new Vector3(90, 90, 0),
                         StateValues::LEVER_DIRECTION_WEST => new Vector3(90, 270, 0),
-                        default => throw new RuntimeException("Invalid lever direction"),
                     }
                 ));
 

--- a/src/Blocks/Permutations/Permutation.php
+++ b/src/Blocks/Permutations/Permutation.php
@@ -7,7 +7,7 @@ use pocketmine\nbt\tag\CompoundTag;
 
 final class Permutation
 {
-    /*** @var BlockComponent[] */
+    /** @var array<string, BlockComponent> */
     private array $components = [];
 
     public function __construct(
@@ -43,7 +43,7 @@ final class Permutation
     }
 
     /**
-     * @return array
+     * @return array<string, BlockComponent>
      */
     public function getComponents(): array
     {

--- a/src/Blocks/Traits/MinecraftTrait.php
+++ b/src/Blocks/Traits/MinecraftTrait.php
@@ -14,9 +14,9 @@ class MinecraftTrait
      * @param State $state
      */
     public function __construct(
-        private TraitIds $identifier,
-        private float  $rotationOffset,
-        private State $state,
+        private readonly TraitIds $identifier,
+        private readonly float    $rotationOffset,
+        private readonly State    $state,
     ) {
     }
 

--- a/src/Blocks/Traits/State.php
+++ b/src/Blocks/Traits/State.php
@@ -35,7 +35,7 @@ readonly class State
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("cardinal_direction", new ByteTag($this->cardinal))
-            ->setTag("facing_direction", new ByteTag($this->facing));
+            ->setTag("cardinal_direction", new ByteTag($this->cardinal ? 1 : 0))
+            ->setTag("facing_direction", new ByteTag($this->facing ? 1 : 0));
     }
 }

--- a/src/Blocks/Vanilla/HeadBlock.php
+++ b/src/Blocks/Vanilla/HeadBlock.php
@@ -10,13 +10,12 @@ use pocketmine\block\utils\MobHeadType;
 class HeadBlock extends MobHead
 {
     protected MobHeadType $mobHeadType = MobHeadType::PLAYER;
-    private int $textureIndex = 0;
 
     public function __construct(
-        BlockIdentifier $idInfo,
-        string          $name,
-        private string  $texture,
-        BlockTypeInfo   $typeInfo
+        BlockIdentifier         $idInfo,
+        string                  $name,
+        private readonly string $texture,
+        BlockTypeInfo           $typeInfo
     ) {
         parent::__construct($idInfo, $name, $typeInfo);
     }

--- a/src/Blocks/Vanilla/NexlyFence.php
+++ b/src/Blocks/Vanilla/NexlyFence.php
@@ -34,7 +34,7 @@ class NexlyFence extends Fence
             $block = $this->getSide($facing);
             if ($block instanceof Fence || $block instanceof FenceGate || $block->getSupportType(Facing::opposite($facing)) === SupportType::FULL) {
                 if (!isset($this->connections[$facing])) {
-                    $this->connections[$facing] = $facing;
+                    $this->connections[$facing] = true;
                     $changed++;
                 }
             } elseif (isset($this->connections[$facing])) {
@@ -53,11 +53,9 @@ class NexlyFence extends Fence
      */
     protected function describeBlockOnlyState(RuntimeDataDescriber $w): void
     {
-        foreach ($this->connections as $facing => $zebi) {
-            $this->connections[$facing] = $facing;
-        }
-
-        $w->horizontalFacingFlags($this->connections);
+        $faces = array_keys($this->connections);
+        $w->horizontalFacingFlags($faces);
+        $this->connections = array_fill_keys(array_values($faces), true);
     }
 
     /**

--- a/src/Blocks/Vanilla/NexlyGlassPane.php
+++ b/src/Blocks/Vanilla/NexlyGlassPane.php
@@ -35,7 +35,7 @@ class NexlyGlassPane extends GlassPane
             $block = $this->getSide($facing);
             if ($block instanceof Thin || $block instanceof Wall || $block->getSupportType(Facing::opposite($facing)) === SupportType::FULL) {
                 if (!isset($this->connections[$facing])) {
-                    $this->connections[$facing] = $facing;
+                    $this->connections[$facing] = true;
                     $changed++;
                 }
             } elseif (isset($this->connections[$facing])) {
@@ -54,11 +54,9 @@ class NexlyGlassPane extends GlassPane
      */
     protected function describeBlockOnlyState(RuntimeDataDescriber $w): void
     {
-        foreach ($this->connections as $facing => $zebi) {
-            $this->connections[$facing] = $facing;
-        }
-
-        $w->horizontalFacingFlags($this->connections);
+        $faces = array_keys($this->connections);
+        $w->horizontalFacingFlags($faces);
+        $this->connections = array_fill_keys(array_values($faces), true);
     }
 
     /**

--- a/src/Events/Attribute/HandlePriority.php
+++ b/src/Events/Attribute/HandlePriority.php
@@ -9,17 +9,17 @@ use pocketmine\event\EventPriority as PMPriority;
 class HandlePriority
 {
     /**
-     * @param int|string $priority
+     * @param int $priority
      */
     public function __construct(
-        protected int|string $priority = PMPriority::NORMAL
+        protected int $priority = PMPriority::NORMAL
     ) {
     }
 
     /**
-     * @return int|string
+     * @return int
      */
-    public function getPriority(): int|string
+    public function getPriority(): int
     {
         return $this->priority;
     }

--- a/src/Events/EventReflected.php
+++ b/src/Events/EventReflected.php
@@ -7,14 +7,17 @@ use WeakReference;
 
 class EventReflected
 {
+    /**
+     * @param WeakReference<object>|null $instanceRef
+     */
     public function __construct(
-        private \Closure           $closure,
-        private ReflectionFunction $ref,
-        private bool               $isStatic,
-        private ?WeakReference     $instanceRef,
-        private ?int               $instanceId,
-        private int                $priority,
-        private bool               $handleCancelled,
+        private readonly \Closure           $closure,
+        private readonly ReflectionFunction $ref,
+        private readonly bool               $isStatic,
+        private readonly ?WeakReference     $instanceRef,
+        private readonly ?int               $instanceId,
+        private readonly int                $priority,
+        private readonly bool               $handleCancelled,
     ) {
     }
 
@@ -43,7 +46,7 @@ class EventReflected
     }
 
     /**
-     * @return WeakReference|null
+     * @return WeakReference<object>|null
      */
     public function getInstanceRef(): ?WeakReference
     {

--- a/src/Events/Impl/ItemRegistryEvent.php
+++ b/src/Events/Impl/ItemRegistryEvent.php
@@ -17,7 +17,7 @@ class ItemRegistryEvent extends Event
      * @param CreativeInfo|null $creativeInfo
      * @return self
      */
-    public function register(string $stringId, Item $item, CreativeInfo $creativeInfo = null): self
+    public function register(string $stringId, Item $item, ?CreativeInfo $creativeInfo = null): self
     {
         NexlyItems::register($stringId, $item, $creativeInfo);
         $this->count++;

--- a/src/Events/Impl/RecipeRegistryEvent.php
+++ b/src/Events/Impl/RecipeRegistryEvent.php
@@ -8,6 +8,7 @@ use Nexly\Recipes\NexlyRecipes;
 use Nexly\Recipes\Types\ShapedRecipe;
 use Nexly\Recipes\Types\ShapelessRecipe;
 use pocketmine\crafting\ShapelessRecipeType;
+use pocketmine\item\Item;
 
 class RecipeRegistryEvent extends Event
 {
@@ -17,14 +18,14 @@ class RecipeRegistryEvent extends Event
     /**
      * Registers a shaped recipe.
      *
-     * @param MinecraftShape|string[] $shape
-     * @param array $ingredients
-     * @param array $outputs
+     * @param MinecraftShape|list<string> $shape
+     * @param array<string, Item|string> $ingredients
+     * @param list<Item|string> $outputs
      * @return self
      */
     public function registerShaped(MinecraftShape|array $shape, array $ingredients, array $outputs): self
     {
-        NexlyRecipes::getInstance()->addRecipe(fn () => new ShapedRecipe($shape, $ingredients, $outputs));
+        NexlyRecipes::getInstance()->addRecipe(fn (): ShapedRecipe => new ShapedRecipe($shape, $ingredients, $outputs));
         $this->shaped++;
         return $this;
     }
@@ -32,14 +33,14 @@ class RecipeRegistryEvent extends Event
     /**
      * Registers a shapeless recipe.
      *
-     * @param array $ingredients
-     * @param array $outputs
+     * @param list<Item|string> $ingredients
+     * @param list<Item|string> $outputs
      * @param ShapelessRecipeType $type
      * @return $this
      */
     public function registerShapeless(array $ingredients, array $outputs, ShapelessRecipeType $type = ShapelessRecipeType::CRAFTING): self
     {
-        NexlyRecipes::getInstance()->addRecipe(fn () => new ShapelessRecipe($type, $ingredients, $outputs));
+        NexlyRecipes::getInstance()->addRecipe(fn (): ShapelessRecipe => new ShapelessRecipe($type, $ingredients, $outputs));
         $this->shapeless++;
         return $this;
     }

--- a/src/Events/NexlyEventManager.php
+++ b/src/Events/NexlyEventManager.php
@@ -23,7 +23,7 @@ class NexlyEventManager
         EventPriority::MONITOR,
     ];
 
-    /** @var EventReflected[] */
+    /** @var array<class-string<Event>, array<int, list<EventReflected>>> */
     private array $handlerCaches = [];
 
     /**
@@ -34,7 +34,7 @@ class NexlyEventManager
      * @param object|null $instance
      * @return void
      */
-    public function listen(string $event, callable $callback, object $instance = null): void
+    public function listen(string $event, callable $callback, ?object $instance = null): void
     {
         if (!\class_exists($event) || !\is_subclass_of($event, Event::class)) {
             throw new \InvalidArgumentException("Event class must exist and be a subclass of " . Event::class . " (got: {$event})");
@@ -61,8 +61,6 @@ class NexlyEventManager
         if (!$rf->isStatic() && $instance === null) {
             throw new \InvalidArgumentException("Cannot use non-static method without instance");
         }
-
-        $this->handlerCaches[$event] ??= [];
 
         $handleCancelled = false;
         $priority = EventPriority::NORMAL;
@@ -98,7 +96,7 @@ class NexlyEventManager
      * @return void
      * @throws ReflectionException
      */
-    public function deafen(string $event, callable $callback = null, object $instance = null): void
+    public function deafen(string $event, ?callable $callback = null, ?object $instance = null): void
     {
         if (!\class_exists($event) || !\is_subclass_of($event, Event::class)) {
             throw new \InvalidArgumentException("Event class must exist and be a subclass of " . Event::class . " (got: {$event})");
@@ -112,7 +110,7 @@ class NexlyEventManager
             return;
         }
 
-        if ($callback === null && $instance !== null) {
+        if ($callback === null) {
             $iid = spl_object_id($instance);
             foreach (self::PRIORITY_ORDER as $p) {
                 if (!isset($this->handlerCaches[$event][$p])) {
@@ -120,7 +118,7 @@ class NexlyEventManager
                 }
                 $this->handlerCaches[$event][$p] = array_values(array_filter(
                     $this->handlerCaches[$event][$p],
-                    static fn (EventReflected $er) => $er->getInstanceId() !== $iid
+                    static fn (EventReflected $er): bool => $er->getInstanceId() !== $iid
                 ));
             }
             return;

--- a/src/Items/Components/DataDriven/ArmorItemComponent.php
+++ b/src/Items/Components/DataDriven/ArmorItemComponent.php
@@ -5,7 +5,6 @@ namespace Nexly\Items\Components\DataDriven;
 use Attribute;
 use Nexly\Items\Components\DataDriven\Types\OreTextureType;
 use pocketmine\item\Armor;
-use pocketmine\item\Item;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\StringTag;
@@ -26,11 +25,11 @@ class ArmorItemComponent extends DataDrivenItemComponent
      * @param Armor $item
      * @return self
      */
-    public static function from(Item $item): self
+    public static function from(Armor $item): self
     {
         return new self(
             OreTextureType::fromItem($item),
-            $item instanceof Armor ? $item->getDefensePoints() : null
+            $item->getDefensePoints()
         );
     }
 

--- a/src/Items/Components/DataDriven/BlockPlacerItemComponent.php
+++ b/src/Items/Components/DataDriven/BlockPlacerItemComponent.php
@@ -17,29 +17,54 @@ class BlockPlacerItemComponent extends DataDrivenItemComponent
 {
     /**
      * @param string $block
-     * @param array $useOn
-     * @param bool $canUseBlockAsIcon
+     * @param list<string> $useOn
+     * @param bool $alignedPlacement
+     * @param bool $replaceBlockItem
      */
     public function __construct(
         private readonly string $block,
         private readonly array $useOn = [],
-        private readonly bool $canUseBlockAsIcon = false,
+        private readonly bool $alignedPlacement = false,
+        private readonly bool $replaceBlockItem = false,
     ) {
+        if ($block === "") {
+            throw new \InvalidArgumentException("Placed block identifier cannot be empty.");
+        }
 
+        if (count($useOn) > 256) {
+            throw new \InvalidArgumentException("Use-on filters cannot contain more than 256 entries.");
+        }
+
+        foreach ($useOn as $filter) {
+            if ($filter === "") {
+                throw new \InvalidArgumentException("Use-on filters must contain non-empty block identifiers.");
+            }
+        }
     }
 
     /**
      * Create a BlockPlacerItemComponent from a Block instance.
      *
      * @param Block $block
+     * @param bool $alignedPlacement
+     * @param bool $replaceBlockItem
      * @param Block ...$useOn
-     * @return $this
+     * @return self
      */
-    public static function from(Block $block, Block ...$useOn): self
-    {
+    public static function from(
+        Block $block,
+        bool $alignedPlacement = false,
+        bool $replaceBlockItem = false,
+        Block ...$useOn
+    ): self {
         return new self(
             GlobalBlockStateHandlers::getSerializer()->serialize($block->getStateId())->getName(),
-            array_map(fn (Block $b) => GlobalBlockStateHandlers::getSerializer()->serialize($b->getStateId())->getName(), $useOn)
+            array_values(array_map(
+                fn (Block $b): string => GlobalBlockStateHandlers::getSerializer()->serialize($b->getStateId())->getName(),
+                $useOn
+            )),
+            $alignedPlacement,
+            $replaceBlockItem
         );
     }
 
@@ -62,7 +87,8 @@ class BlockPlacerItemComponent extends DataDrivenItemComponent
     {
         return CompoundTag::create()
             ->setTag("block", new StringTag($this->block))
-            ->setTag("canUseBlockAsIcon", new ByteTag($this->canUseBlockAsIcon))
-            ->setTag("use_on", new ListTag($this->useOn, NBT::TAG_String));
+            ->setTag("aligned_placement", new ByteTag($this->alignedPlacement ? 1 : 0))
+            ->setTag("replace_block_item", new ByteTag($this->replaceBlockItem ? 1 : 0))
+            ->setTag("use_on", new ListTag(array_map(fn (string $block): StringTag => new StringTag($block), $this->useOn), NBT::TAG_String));
     }
 }

--- a/src/Items/Components/DataDriven/BundleInteractionItemComponent.php
+++ b/src/Items/Components/DataDriven/BundleInteractionItemComponent.php
@@ -10,10 +10,10 @@ use pocketmine\nbt\tag\IntTag;
 class BundleInteractionItemComponent extends DataDrivenItemComponent
 {
     public function __construct(
-        private readonly int $capacity,
+        private readonly int $numViewableSlots = 12,
     ) {
-        if ($this->capacity < 1 || $this->capacity > 64) {
-            throw new \InvalidArgumentException("Capacity must be between 1 and 64");
+        if ($this->numViewableSlots < 1 || $this->numViewableSlots > 64) {
+            throw new \InvalidArgumentException("Viewable slots must be between 1 and 64.");
         }
     }
 
@@ -35,6 +35,6 @@ class BundleInteractionItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("num_viewable_slots", new IntTag($this->capacity));
+            ->setTag("num_viewable_slots", new IntTag($this->numViewableSlots));
     }
 }

--- a/src/Items/Components/DataDriven/CompostableItemComponent.php
+++ b/src/Items/Components/DataDriven/CompostableItemComponent.php
@@ -4,14 +4,17 @@ namespace Nexly\Items\Components\DataDriven;
 
 use Attribute;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\FloatTag;
+use pocketmine\nbt\tag\IntTag;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class CompostableItemComponent extends DataDrivenItemComponent
 {
     public function __construct(
-        private readonly float $chance,
+        private readonly int $compostingChance,
     ) {
+        if ($compostingChance < 1 || $compostingChance > 100) {
+            throw new \InvalidArgumentException("Composting chance must be between 1 and 100.");
+        }
     }
 
     /**
@@ -32,6 +35,6 @@ class CompostableItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("composting_chance", new FloatTag($this->chance));
+            ->setTag("composting_chance", new IntTag($this->compostingChance));
     }
 }

--- a/src/Items/Components/DataDriven/CooldownItemComponent.php
+++ b/src/Items/Components/DataDriven/CooldownItemComponent.php
@@ -3,6 +3,7 @@
 namespace Nexly\Items\Components\DataDriven;
 
 use Attribute;
+use Nexly\Items\Components\DataDriven\Types\ItemCooldownAction;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\StringTag;
@@ -12,8 +13,12 @@ class CooldownItemComponent extends DataDrivenItemComponent
 {
     public function __construct(
         private readonly float $duration,
-        private readonly string $category = ""
+        private readonly string $category = "",
+        private readonly ItemCooldownAction $type = ItemCooldownAction::USE,
     ) {
+        if ($duration < 0.0) {
+            throw new \InvalidArgumentException("Cooldown duration cannot be negative.");
+        }
     }
 
     /**
@@ -35,6 +40,7 @@ class CooldownItemComponent extends DataDrivenItemComponent
     {
         return CompoundTag::create()
             ->setTag("duration", new FloatTag($this->duration))
-            ->setTag("category", new StringTag($this->category));
+            ->setTag("category", new StringTag($this->category))
+            ->setTag("type", new StringTag($this->type->getValue()));
     }
 }

--- a/src/Items/Components/DataDriven/DamageAbsorptionItemComponent.php
+++ b/src/Items/Components/DataDriven/DamageAbsorptionItemComponent.php
@@ -7,16 +7,21 @@ use Nexly\Items\Components\DataDriven\Types\DamageCause;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\ListTag;
+use pocketmine\nbt\tag\StringTag;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class DamageAbsorptionItemComponent extends DataDrivenItemComponent
 {
     /**
-     * @param DamageCause[] $causes
+     * @param DamageCause[] $absorbableCauses
      */
     public function __construct(
-        private readonly array $causes,
+        private readonly array $absorbableCauses,
     ) {
+        if ($absorbableCauses === []) {
+            throw new \InvalidArgumentException("At least one absorbable damage cause is required.");
+        }
+
     }
 
     /**
@@ -37,6 +42,6 @@ class DamageAbsorptionItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("absorbable_causes", new ListTag(array_map(fn (DamageCause $cause) => $cause->getValue(), $this->causes), NBT::TAG_String));
+            ->setTag("absorbable_causes", new ListTag(array_map(fn (DamageCause $cause): StringTag => new StringTag($cause->getValue()), $this->absorbableCauses), NBT::TAG_String));
     }
 }

--- a/src/Items/Components/DataDriven/DataDrivenComponentIds.php
+++ b/src/Items/Components/DataDriven/DataDrivenComponentIds.php
@@ -4,11 +4,14 @@ namespace Nexly\Items\Components\DataDriven;
 
 enum DataDrivenComponentIds: string
 {
+    /** @deprecated Internal client component; use WEARABLE for protection. */
     case ARMOR = "minecraft:armor";
     case BUNDLE_INTERACTION = "minecraft:bundle_interaction";
+    /** @deprecated Use USE_MODIFIERS. */
     case CHARGEABLE = "minecraft:chargeable";
     case COMPOSTABLE = "minecraft:compostable";
     case COOLDOWN = "minecraft:cooldown";
+    /** @deprecated Script custom_components is no longer supported. */
     case CUSTOM_COMPONENTS = "minecraft:custom_components";
     case DAMAGE_ABSORPTION = "minecraft:damage_absorption";
     case DIGGER = "minecraft:digger";
@@ -24,23 +27,25 @@ enum DataDrivenComponentIds: string
     case BLOCK_PLACER = "minecraft:block_placer";
     case PROJECTILE = "minecraft:projectile";
     case RECORD = "minecraft:record";
+    /** @deprecated No longer usable in current custom content. */
     case RENDER_OFFSETS = "minecraft:render_offsets";
     case REPAIRABLE = "minecraft:repairable";
     case SHOOTER = "minecraft:shooter";
     case STORAGE = "minecraft:storage_item";
-    case STORAGE_WEIGHT_LIMIT = "minecraft:storage_item_weight_limit";
-    case STORAGE_WEIGHT_MODIFIER = "minecraft:storage_item_weight_modifier";
+    case STORAGE_WEIGHT_LIMIT = "minecraft:storage_weight_limit";
+    case STORAGE_WEIGHT_MODIFIER = "minecraft:storage_weight_modifier";
     case TAGS = "minecraft:tags";
     case THROWABLE = "minecraft:throwable";
     case USE_MODIFIERS = "minecraft:use_modifiers";
+    /** @deprecated Use DAMAGE and the modern weapon components. */
     case WEAPON = "minecraft:weapon";
     case WEARABLE = "minecraft:wearable";
+    /** @deprecated Internal client metadata, not a public item component. */
     case PUBLISHER_ON_USE_ON = "minecraft:publisher_on_use_on";
     case SWING_DURATION = "minecraft:swing_duration";
     case SWING_SOUNDS = "minecraft:swing_sounds";
     case PIERCING_WEAPON = "minecraft:piercing_weapon";
     case KINETIC_WEAPON = "minecraft:kinetic_weapon";
-    case KINETIC_WEAPON_KINETIC_EFFECT_CONDITIONS = "minecraft:kinetic_weapon_kinetic_effect_conditions";
 
     /**
      * Returns the name of the component.

--- a/src/Items/Components/DataDriven/DataDrivenItemBuilder.php
+++ b/src/Items/Components/DataDriven/DataDrivenItemBuilder.php
@@ -16,7 +16,6 @@ use Nexly\Items\Components\DataDriven\Property\PropertyItemComponent;
 use Nexly\Items\Components\DataDriven\Property\ShouldDespawnProperty;
 use Nexly\Items\Components\DataDriven\Property\StackedByDataProperty;
 use Nexly\Items\Components\DataDriven\Property\UseAnimationProperty;
-use Nexly\Items\Components\DataDriven\Property\UseDurationProperty;
 use Nexly\Items\Components\DataDriven\Types\IgnoreBlockVisual;
 use Nexly\Items\Components\DataDriven\Types\ItemEnchantSlot;
 use Nexly\Items\Components\DataDriven\Types\ItemRepair;
@@ -30,9 +29,7 @@ use pocketmine\item\Bucket;
 use pocketmine\item\Durable;
 use pocketmine\item\Dye;
 use pocketmine\item\Food;
-use pocketmine\item\ProjectileItem;
 use pocketmine\item\Record;
-use pocketmine\item\SpawnEgg;
 use pocketmine\item\Sword;
 use pocketmine\item\TieredTool;
 use pocketmine\item\Tool;
@@ -50,7 +47,7 @@ class DataDrivenItemBuilder extends ItemBuilder
     /** @var DataDrivenItemComponent[] */
     private array $components = [];
 
-    public static function create(): DataDrivenItemBuilder
+    public static function create(): self
     {
         return new self();
     }
@@ -208,10 +205,6 @@ class DataDrivenItemBuilder extends ItemBuilder
             $this->addProperty(BlockProperty::from($block));
         }
 
-        if ($item instanceof Food) {
-            $this->addProperty(new UseDurationProperty(20));
-        }
-
         $this->addProperty(UseAnimationProperty::fromItem($item));
         $this->addProperty(EnchantableSlotProperty::fromItem($item));
         $this->addProperty(EnchantableValueProperty::fromItem($item));
@@ -239,25 +232,24 @@ class DataDrivenItemBuilder extends ItemBuilder
 
             $items = [];
             if ($item instanceof Armor) {
-                $items[] = ItemRepair::from(RepairableItemComponent::VANILLA_COST_FORMULE, match (true) {
-                    $item->getMaterial() === VanillaArmorMaterials::LEATHER() => VanillaItems::LEATHER(),
-                    $item->getMaterial() === VanillaArmorMaterials::IRON() => VanillaItems::IRON_INGOT(),
-                    $item->getMaterial() === VanillaArmorMaterials::GOLD() => VanillaItems::GOLD_INGOT(),
-                    $item->getMaterial() === VanillaArmorMaterials::DIAMOND() => VanillaItems::DIAMOND(),
-                    $item->getMaterial() === VanillaArmorMaterials::NETHERITE() => VanillaItems::NETHERITE_INGOT(),
-                    $item->getMaterial() === VanillaArmorMaterials::TURTLE() => VanillaItems::SCUTE(),
+                $items[] = ItemRepair::from(RepairableItemComponent::VANILLA_COST_FORMULE, match ($item->getMaterial()) {
+                    VanillaArmorMaterials::LEATHER() => VanillaItems::LEATHER(),
+                    VanillaArmorMaterials::IRON() => VanillaItems::IRON_INGOT(),
+                    VanillaArmorMaterials::GOLD() => VanillaItems::GOLD_INGOT(),
+                    VanillaArmorMaterials::DIAMOND() => VanillaItems::DIAMOND(),
+                    VanillaArmorMaterials::NETHERITE() => VanillaItems::NETHERITE_INGOT(),
+                    VanillaArmorMaterials::TURTLE() => VanillaItems::SCUTE(),
                     default => VanillaItems::AIR(),
                 });
             } elseif ($item instanceof TieredTool) {
-                $items[] = ItemRepair::from(RepairableItemComponent::VANILLA_COST_FORMULE, ...match (true) {
-                    $item->getTier() === ToolTier::WOOD => [VanillaBlocks::OAK_WOOD()->asItem(), VanillaBlocks::OAK_LOG()->asItem(), VanillaBlocks::BIRCH_LOG()->asItem(), VanillaBlocks::SPRUCE_LOG()->asItem(), VanillaBlocks::JUNGLE_LOG()->asItem(), VanillaBlocks::ACACIA_LOG()->asItem(), VanillaBlocks::DARK_OAK_LOG()->asItem()],
-                    $item->getTier() === ToolTier::STONE => [VanillaBlocks::COBBLESTONE()->asItem(), VanillaBlocks::STONE()->asItem()],
-                    $item->getTier() === ToolTier::COPPER => [VanillaItems::COPPER_INGOT()],
-                    $item->getTier() === ToolTier::IRON => [VanillaItems::IRON_INGOT()],
-                    $item->getTier() === ToolTier::GOLD => [VanillaItems::GOLD_INGOT()],
-                    $item->getTier() === ToolTier::DIAMOND => [VanillaItems::DIAMOND()],
-                    $item->getTier() === ToolTier::NETHERITE => [VanillaItems::NETHERITE_INGOT()],
-                    default => [VanillaItems::AIR()],
+                $items[] = ItemRepair::from(RepairableItemComponent::VANILLA_COST_FORMULE, ...match ($item->getTier()) {
+                    ToolTier::WOOD => [VanillaBlocks::OAK_WOOD()->asItem(), VanillaBlocks::OAK_LOG()->asItem(), VanillaBlocks::BIRCH_LOG()->asItem(), VanillaBlocks::SPRUCE_LOG()->asItem(), VanillaBlocks::JUNGLE_LOG()->asItem(), VanillaBlocks::ACACIA_LOG()->asItem(), VanillaBlocks::DARK_OAK_LOG()->asItem()],
+                    ToolTier::STONE => [VanillaBlocks::COBBLESTONE()->asItem(), VanillaBlocks::STONE()->asItem()],
+                    ToolTier::COPPER => [VanillaItems::COPPER_INGOT()],
+                    ToolTier::IRON => [VanillaItems::IRON_INGOT()],
+                    ToolTier::GOLD => [VanillaItems::GOLD_INGOT()],
+                    ToolTier::DIAMOND => [VanillaItems::DIAMOND()],
+                    ToolTier::NETHERITE => [VanillaItems::NETHERITE_INGOT()],
                 });
             }
 
@@ -266,12 +258,11 @@ class DataDrivenItemBuilder extends ItemBuilder
 
         if ($item instanceof Armor) {
             $this->addComponent(new WearableItemComponent(ItemSlot::fromArmorTypeInfo($item->getArmorSlot()), $item->getDefensePoints()));
-            $this->addComponent(ArmorItemComponent::from($item));
         }
 
         $block = $item->getBlock();
         if (!($block instanceof Air)) {
-            $this->addComponent(BlockPlacerItemComponent::from($block));
+            $this->addComponent(BlockPlacerItemComponent::from($block, replaceBlockItem: true));
         }
 
         $cooldown = $item->getCooldownTicks();
@@ -280,24 +271,16 @@ class DataDrivenItemBuilder extends ItemBuilder
         }
 
         if ($item instanceof Dye) {
-            $this->addComponent(new DyeableItemComponent(sprintf("%02X%02X%02X%02X", ($color = $item->getColor())->r, $color->g, $color->b, $color->a)));
-        }
-
-        if ($item instanceof SpawnEgg) {
-            $this->addComponent(new EntityPlacerItemComponent());
+            $color = $item->getColor()->getRgbValue();
+            $this->addComponent(new DyeableItemComponent(sprintf("#%02X%02X%02X", $color->getR(), $color->getG(), $color->getB())));
         }
 
         if ($item instanceof Food) {
-            $this->addComponent(new FoodItemComponent(
-                $item->getFoodRestore(),
-                $item->getSaturationRestore(),
-                !$item->requiresHunger()
-            ));
-        }
+            $nutrition = $item->getFoodRestore();
+            $saturationModifier = $nutrition > 0 ? $item->getSaturationRestore() / ($nutrition * 2) : 0.0;
 
-        if ($item instanceof ProjectileItem) {
-            $this->addComponent(new ProjectileItemComponent());
-            $this->addComponent(new ThrowableItemComponent());
+            $this->addComponent(new FoodItemComponent($nutrition, $saturationModifier, !$item->requiresHunger()));
+            $this->addComponent(new UseModifiersItemComponent(1.6, 0.35));
         }
 
         if ($item instanceof Record) {

--- a/src/Items/Components/DataDriven/DiggerItemComponent.php
+++ b/src/Items/Components/DataDriven/DiggerItemComponent.php
@@ -4,6 +4,7 @@ namespace Nexly\Items\Components\DataDriven;
 
 use Attribute;
 use pocketmine\block\Block;
+use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
@@ -14,9 +15,12 @@ use pocketmine\world\format\io\GlobalBlockStateHandlers;
 #[Attribute(Attribute::TARGET_CLASS)]
 class DiggerItemComponent extends DataDrivenItemComponent
 {
+    /**
+     * @param list<CompoundTag> $destroySpeeds
+     */
     public function __construct(
-        private readonly bool $efficiency,
-        private array $diggers
+        private readonly bool $useEfficiency = false,
+        private array $destroySpeeds = []
     ) {
     }
 
@@ -39,13 +43,14 @@ class DiggerItemComponent extends DataDrivenItemComponent
      */
     public function addBlock(Block $block, int $speed): self
     {
+        if ($speed < 0) {
+            throw new \InvalidArgumentException("Destroy speed cannot be negative.");
+        }
+
         $blockName = GlobalBlockStateHandlers::getSerializer()->serialize($block->getStateId())->getName();
-        $this->diggers[] = CompoundTag::create()->setTag(
-            "block",
-            CompoundTag::create()
-            ->setTag("name", new StringTag($blockName))
-            ->setTag("speed", new IntTag($speed))
-        );
+        $this->destroySpeeds[] = CompoundTag::create()
+            ->setTag("block", CompoundTag::create()->setTag("name", new StringTag($blockName)))
+            ->setTag("speed", new IntTag($speed));
         return $this;
     }
 
@@ -67,15 +72,24 @@ class DiggerItemComponent extends DataDrivenItemComponent
     /**
      * Add a tag with its corresponding speed to the digger component.
      *
-     * @param array|string $tags
+     * @param list<string>|string $tags
      * @param int $speed
      * @return $this
      */
     public function addTag(array|string $tags, int $speed): self
     {
-        $this->diggers[] = CompoundTag::create()->setTag("block", CompoundTag::create()
-            ->setString("tags", "query.any_tag(" . (is_string($tags) ? "'$tags'" : implode(", ", array_map(fn (string $tag) => "'$tag'", $tags))) . ")"))
-            ->setInt("speed", $speed);
+        $tags = is_string($tags) ? [$tags] : $tags;
+        if ($tags === [] || in_array("", $tags, true)) {
+            throw new \InvalidArgumentException("Tags must contain at least one non-empty string.");
+        }
+
+        if ($speed < 0) {
+            throw new \InvalidArgumentException("Destroy speed cannot be negative.");
+        }
+
+        $this->destroySpeeds[] = CompoundTag::create()
+            ->setTag("block", CompoundTag::create()->setString("tags", "q.any_tag(" . implode(", ", array_map(fn (string $tag): string => "'$tag'", $tags)) . ")"))
+            ->setTag("speed", new IntTag($speed));
         return $this;
     }
 
@@ -87,8 +101,7 @@ class DiggerItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("on_dig", CompoundTag::create())
-            ->setTag("use_efficiency", new ByteTag($this->efficiency))
-            ->setTag("destroy_speeds", new ListTag($this->diggers, CompoundTag::class));
+            ->setTag("use_efficiency", new ByteTag($this->useEfficiency ? 1 : 0))
+            ->setTag("destroy_speeds", new ListTag($this->destroySpeeds, NBT::TAG_Compound));
     }
 }

--- a/src/Items/Components/DataDriven/DurabilityItemComponent.php
+++ b/src/Items/Components/DataDriven/DurabilityItemComponent.php
@@ -10,23 +10,23 @@ use pocketmine\nbt\tag\IntTag;
 class DurabilityItemComponent extends DataDrivenItemComponent
 {
     public function __construct(
-        private readonly int $durability,
-        private readonly int $min = 0,
-        private readonly int $max = 0,
+        private readonly int $maxDurability,
+        private readonly int $damageChanceMin = 100,
+        private readonly int $damageChanceMax = 100,
     ) {
-        if ($durability < 1) {
-            throw new \InvalidArgumentException("Durability must be at least 1");
+        if ($maxDurability < 0) {
+            throw new \InvalidArgumentException("Maximum durability cannot be negative.");
         }
 
-        if ($min < 0 || $max < 0) {
+        if ($damageChanceMin < 0 || $damageChanceMax < 0) {
             throw new \InvalidArgumentException("Min and Max damage chance must be at least 0");
         }
 
-        if ($min > $max) {
+        if ($damageChanceMin > $damageChanceMax) {
             throw new \InvalidArgumentException("Min damage chance cannot be greater than Max damage chance");
         }
 
-        if ($max > 100) {
+        if ($damageChanceMax > 100) {
             throw new \InvalidArgumentException("Max damage chance cannot be greater than 100");
         }
     }
@@ -49,12 +49,10 @@ class DurabilityItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("max_durability", new IntTag($this->durability))
-            ->setTag(
-                "damage_chance",
-                CompoundTag::create()
-                ->setTag("min", new IntTag($this->min))
-                ->setTag("max", new IntTag($this->max))
+            ->setTag("max_durability", new IntTag($this->maxDurability))
+            ->setTag("damage_chance", CompoundTag::create()
+                ->setTag("min", new IntTag($this->damageChanceMin))
+                ->setTag("max", new IntTag($this->damageChanceMax))
             );
     }
 }

--- a/src/Items/Components/DataDriven/DurabilitySensorItemComponent.php
+++ b/src/Items/Components/DataDriven/DurabilitySensorItemComponent.php
@@ -11,10 +11,13 @@ use pocketmine\nbt\tag\ListTag;
 #[Attribute(Attribute::TARGET_CLASS)]
 class DurabilitySensorItemComponent extends DataDrivenItemComponent
 {
+    /**
+     * @param list<DurabilityThreshold> $durabilityThresholds
+     */
     public function __construct(
-        private readonly array $thresholds,
+        private readonly array $durabilityThresholds,
     ) {
-        if (empty($this->thresholds)) {
+        if (empty($this->durabilityThresholds)) {
             throw new \InvalidArgumentException("Thresholds array cannot be empty.");
         }
     }
@@ -37,6 +40,6 @@ class DurabilitySensorItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("durability_thresholds", new ListTag(array_map(fn (DurabilityThreshold $threshold) => $threshold->toNBT(), $this->thresholds), NBT::TAG_Compound));
+            ->setTag("durability_thresholds", new ListTag(array_map(fn (DurabilityThreshold $threshold): CompoundTag => $threshold->toNBT(), $this->durabilityThresholds), NBT::TAG_Compound));
     }
 }

--- a/src/Items/Components/DataDriven/DyeableItemComponent.php
+++ b/src/Items/Components/DataDriven/DyeableItemComponent.php
@@ -9,12 +9,27 @@ use pocketmine\nbt\tag\StringTag;
 #[Attribute(Attribute::TARGET_CLASS)]
 class DyeableItemComponent extends DataDrivenItemComponent
 {
+    private readonly string $defaultColor;
+
+    /**
+     * @param string|array{int, int, int} $defaultColor
+     */
     public function __construct(
-        private readonly string $color = "#ffffff",
+        string|array $defaultColor = "#FFFFFF",
     ) {
-        if (!preg_match('/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/', $color)) {
-            throw new \InvalidArgumentException("Invalid color format. Use hex format like #RRGGBB or #RGB.");
+        if (is_array($defaultColor)) {
+            if (array_filter($defaultColor, fn (int $channel): bool => $channel < 0 || $channel > 255) !== []) {
+                throw new \InvalidArgumentException("RGB color must contain three integer channels between 0 and 255.");
+            }
+
+            $defaultColor = sprintf("#%02X%02X%02X", ...$defaultColor);
         }
+
+        if (!preg_match('/^#[A-Fa-f0-9]{6}$/', $defaultColor)) {
+            throw new \InvalidArgumentException("Invalid color format. Use #RRGGBB.");
+        }
+
+        $this->defaultColor = $defaultColor;
     }
 
     /**
@@ -35,6 +50,6 @@ class DyeableItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("default_color", new StringTag($this->color));
+            ->setTag("default_color", new StringTag($this->defaultColor));
     }
 }

--- a/src/Items/Components/DataDriven/EnchantableItemComponent.php
+++ b/src/Items/Components/DataDriven/EnchantableItemComponent.php
@@ -38,7 +38,7 @@ class EnchantableItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("slot", new StringTag($this->slot->getName()))
+            ->setTag("slot", new StringTag($this->slot->getValue()))
             ->setTag("value", new IntTag($this->value));
     }
 }

--- a/src/Items/Components/DataDriven/EntityPlacerItemComponent.php
+++ b/src/Items/Components/DataDriven/EntityPlacerItemComponent.php
@@ -15,30 +15,49 @@ class EntityPlacerItemComponent extends DataDrivenItemComponent
 {
     /**
      * @param string $entity
-     * @param string[] $dispenseOn
-     * @param string[] $useOn
+     * @param list<string> $dispenseOn
+     * @param list<string> $useOn
      */
     public function __construct(
-        private readonly string $entity = "none",
+        private readonly string $entity,
         private readonly array $dispenseOn = [],
         private readonly array $useOn = [],
     ) {
+        if ($entity === "") {
+            throw new \InvalidArgumentException("Entity identifier cannot be empty.");
+        }
+
+        if (count($dispenseOn) > 256 || count($useOn) > 256) {
+            throw new \InvalidArgumentException("Entity placer filters cannot contain more than 256 entries.");
+        }
+
+        foreach ([...$dispenseOn, ...$useOn] as $filter) {
+            if ($filter === "") {
+                throw new \InvalidArgumentException("Entity placer filters must contain non-empty block identifiers.");
+            }
+        }
     }
 
     /**
      * Create an EntityPlacerItemComponent from the given parameters.
      *
      * @param string $entity
-     * @param Block[] $dispenseOn
-     * @param Block[] $useOn
+     * @param list<Block> $dispenseOn
+     * @param list<Block> $useOn
      * @return self
      */
     public static function from(string $entity, array $dispenseOn = [], array $useOn = []): self
     {
         return new self(
             $entity,
-            array_map(fn (Block $block) => GlobalBlockStateHandlers::getSerializer()->serialize($block->getStateId())->getName(), $dispenseOn),
-            array_map(fn (Block $block) => GlobalBlockStateHandlers::getSerializer()->serialize($block->getStateId())->getName(), $useOn)
+            array_map(
+                fn (Block $block): string => GlobalBlockStateHandlers::getSerializer()->serialize($block->getStateId())->getName(),
+                $dispenseOn
+            ),
+            array_map(
+                fn (Block $block): string => GlobalBlockStateHandlers::getSerializer()->serialize($block->getStateId())->getName(),
+                $useOn
+            )
         );
     }
 
@@ -61,7 +80,7 @@ class EntityPlacerItemComponent extends DataDrivenItemComponent
     {
         return CompoundTag::create()
             ->setTag("entity", new StringTag($this->entity))
-            ->setTag("dispense_on", new ListTag(array_map(fn (string $name) => new StringTag($name), $this->dispenseOn), NBT::TAG_String))
-            ->setTag("use_on", new ListTag(array_map(fn (string $name) => new StringTag($name), $this->useOn), NBT::TAG_String));
+            ->setTag("dispense_on", new ListTag(array_map(fn (string $name): StringTag => new StringTag($name), $this->dispenseOn), NBT::TAG_String))
+            ->setTag("use_on", new ListTag(array_map(fn (string $name): StringTag => new StringTag($name), $this->useOn), NBT::TAG_String));
     }
 }

--- a/src/Items/Components/DataDriven/FireResistantItemComponent.php
+++ b/src/Items/Components/DataDriven/FireResistantItemComponent.php
@@ -35,6 +35,6 @@ class FireResistantItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("value", new ByteTag($this->value));
+            ->setTag("value", new ByteTag($this->value ? 1 : 0));
     }
 }

--- a/src/Items/Components/DataDriven/FoodItemComponent.php
+++ b/src/Items/Components/DataDriven/FoodItemComponent.php
@@ -3,16 +3,11 @@
 namespace Nexly\Items\Components\DataDriven;
 
 use Attribute;
-use Nexly\Items\Components\DataDriven\Types\ItemCooldownType;
-use Nexly\Items\Components\DataDriven\Types\ItemUseActionType;
-use Nexly\Items\Components\Legacy\Types\LegacyEffect;
 use pocketmine\item\Item;
-use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\IntTag;
-use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\network\mcpe\convert\TypeConverter;
 
@@ -23,26 +18,21 @@ class FoodItemComponent extends DataDrivenItemComponent
      * @param int $nutrition
      * @param float $saturationModifier
      * @param bool $canAlwaysEat
-     * @param ItemCooldownType $cooldownType
-     * @param int $cooldownTick
-     * @param string $usingConvertsTo
-     * @param ItemUseActionType $useActionType
-     * @param float[] $onUseRange
-     * @param LegacyEffect[] $effects
-     * @param int[] $removeEffects
+     * @param string|null $usingConvertsTo
      */
     public function __construct(
-        private readonly int                 $nutrition,
-        private readonly float               $saturationModifier,
-        private readonly bool                $canAlwaysEat = false,
-        private readonly ItemCooldownType  $cooldownType = ItemCooldownType::NONE,
-        private readonly int                 $cooldownTick = 0,
-        private string                       $usingConvertsTo = "air",
-        private readonly ItemUseActionType $useActionType = ItemUseActionType::NONE,
-        private readonly array               $onUseRange = [],
-        private readonly array               $effects = [],
-        private readonly array               $removeEffects = [],
+        private readonly int $nutrition,
+        private readonly float $saturationModifier,
+        private readonly bool $canAlwaysEat = false,
+        private ?string $usingConvertsTo = null,
     ) {
+        if ($nutrition < 0) {
+            throw new \InvalidArgumentException("Nutrition cannot be negative.");
+        }
+
+        if ($saturationModifier < 0.0) {
+            throw new \InvalidArgumentException("Saturation modifier cannot be negative.");
+        }
     }
 
     /**
@@ -63,7 +53,7 @@ class FoodItemComponent extends DataDrivenItemComponent
     public function setUsingConvertsTo(Item $item): void
     {
         [$rId] = ($converter = TypeConverter::getInstance())->getItemTranslator()->toNetworkId($item);
-        if ($rId == null) {
+        if ($rId === null) {
             throw new \InvalidArgumentException("Item does not have a valid network ID");
         }
 
@@ -77,16 +67,15 @@ class FoodItemComponent extends DataDrivenItemComponent
      */
     public function toNBT(): CompoundTag
     {
-        return CompoundTag::create()
+        $nbt = CompoundTag::create()
             ->setTag("nutrition", new IntTag($this->nutrition))
             ->setTag("saturation_modifier", new FloatTag($this->saturationModifier))
-            ->setTag("can_always_eat", new ByteTag($this->canAlwaysEat))
-            ->setTag("cooldown_type", new StringTag($this->cooldownType->getValue()))
-            ->setTag("cooldown_time", new IntTag($this->cooldownTick))
-            ->setTag("using_converts_to", CompoundTag::create()->setTag("name", new StringTag($this->usingConvertsTo)))
-            ->setTag("on_use_action", new IntTag($this->useActionType->getValue()))
-            ->setTag("on_use_range", new ListTag(array_map(fn (float $value) => new FloatTag($value), $this->onUseRange), NBT::TAG_Float))
-            ->setTag("effects", new ListTag(array_map(fn (LegacyEffect $effect) => $effect->toNBT(), $this->effects), NBT::TAG_Compound))
-            ->setTag("remove_effects", new ListTag(array_map(fn (int $value) => new IntTag($value), $this->removeEffects), NBT::TAG_Int));
+            ->setTag("can_always_eat", new ByteTag($this->canAlwaysEat ? 1 : 0));
+
+        if ($this->usingConvertsTo !== null) {
+            $nbt->setTag("using_converts_to", CompoundTag::create()->setTag("name", new StringTag($this->usingConvertsTo)));
+        }
+
+        return $nbt;
     }
 }

--- a/src/Items/Components/DataDriven/FuelItemComponent.php
+++ b/src/Items/Components/DataDriven/FuelItemComponent.php
@@ -10,7 +10,7 @@ use pocketmine\nbt\tag\FloatTag;
 class FuelItemComponent extends DataDrivenItemComponent
 {
     /**
-     * @param bool $value
+     * @param float $duration
      */
     public function __construct(
         private readonly float $duration

--- a/src/Items/Components/DataDriven/KineticWeaponItemComponent.php
+++ b/src/Items/Components/DataDriven/KineticWeaponItemComponent.php
@@ -3,7 +3,8 @@
 namespace Nexly\Items\Components\DataDriven;
 
 use Attribute;
-use Nexly\Items\Components\DataDriven\KineticWeaponKineticEffectConditionsItemComponent as DamageConditions;
+use Nexly\Items\Components\DataDriven\Types\FloatRange;
+use Nexly\Items\Components\DataDriven\Types\KineticEffectConditions;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\IntTag;
@@ -11,22 +12,24 @@ use pocketmine\nbt\tag\IntTag;
 /**
  * @see https://learn.microsoft.com/en-us/minecraft/creator/reference/content/itemreference/examples/itemcomponents/minecraft_kinetic_weapon?view=minecraft-bedrock-stable
  * @since 1.21.120
- * @internal
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 class KineticWeaponItemComponent extends DataDrivenItemComponent
 {
     public function __construct(
         private readonly float $hitboxMargin = 0.0,
-        private readonly int $min = 0,
-        private readonly int $max = 3,
-        private readonly float             $damageModifier = 0.0,
-        private readonly float             $damageMultiplier = 1.0,
-        private readonly int               $delay = 0,
-        private readonly ?DamageConditions $damageConditions = null,
-        private readonly ?DamageConditions $dismoutConditions = null,
-        private readonly ?DamageConditions $knockbackConditions = null,
+        private readonly FloatRange $reach = new FloatRange(0.0, 3.0),
+        private readonly ?FloatRange $creativeReach = null,
+        private readonly float $damageModifier = 0.0,
+        private readonly float $damageMultiplier = 1.0,
+        private readonly int $delay = 0,
+        private readonly ?KineticEffectConditions $damageConditions = null,
+        private readonly ?KineticEffectConditions $dismountConditions = null,
+        private readonly ?KineticEffectConditions $knockbackConditions = null,
     ) {
+        if ($hitboxMargin < 0.0) {
+            throw new \InvalidArgumentException("Hitbox margin cannot be negative.");
+        }
     }
 
     /**
@@ -51,24 +54,25 @@ class KineticWeaponItemComponent extends DataDrivenItemComponent
             $nbt = $nbt->setTag("damage_conditions", $this->damageConditions->toNBT());
         }
 
-        if ($this->dismoutConditions !== null) {
-            $nbt = $nbt->setTag("dismount_conditions", $this->dismoutConditions->toNBT());
+        if ($this->dismountConditions !== null) {
+            $nbt = $nbt->setTag("dismount_conditions", $this->dismountConditions->toNBT());
         }
 
         if ($this->knockbackConditions !== null) {
             $nbt = $nbt->setTag("knockback_conditions", $this->knockbackConditions->toNBT());
         }
 
-        return $nbt
+        $nbt
             ->setTag("hitbox_margin", new FloatTag($this->hitboxMargin))
-            ->setTag(
-                "reach",
-                CompoundTag::create()
-                ->setTag("min", new IntTag($this->min))
-                ->setTag("max", new IntTag($this->max))
-            )
+            ->setTag("reach", $this->reach->toNBT())
             ->setTag("damage_modifier", new FloatTag($this->damageModifier))
             ->setTag("damage_multiplier", new FloatTag($this->damageMultiplier))
             ->setTag("delay", new IntTag($this->delay));
+
+        if ($this->creativeReach !== null) {
+            $nbt->setTag("creative_reach", $this->creativeReach->toNBT());
+        }
+
+        return $nbt;
     }
 }

--- a/src/Items/Components/DataDriven/PiercingWeaponItemComponent.php
+++ b/src/Items/Components/DataDriven/PiercingWeaponItemComponent.php
@@ -3,22 +3,25 @@
 namespace Nexly\Items\Components\DataDriven;
 
 use Attribute;
+use Nexly\Items\Components\DataDriven\Types\FloatRange;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\IntTag;
+use pocketmine\nbt\tag\FloatTag;
 
 /**
  * @see https://learn.microsoft.com/en-us/minecraft/creator/reference/content/itemreference/examples/itemcomponents/minecraft_piercing_weapon?view=minecraft-bedrock-stable
  * @since 1.21.120
- * @internal
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 class PiercingWeaponItemComponent extends DataDrivenItemComponent
 {
     public function __construct(
-        private readonly float $hitboxMargin = 0,
-        private readonly int   $min = 0,
-        private readonly int   $max = 3,
+        private readonly float $hitboxMargin = 0.0,
+        private readonly FloatRange $reach = new FloatRange(0.0, 3.0),
+        private readonly ?FloatRange $creativeReach = null,
     ) {
+        if ($hitboxMargin < 0.0) {
+            throw new \InvalidArgumentException("Hitbox margin cannot be negative.");
+        }
     }
 
     /**
@@ -38,13 +41,14 @@ class PiercingWeaponItemComponent extends DataDrivenItemComponent
      */
     public function toNBT(): CompoundTag
     {
-        return CompoundTag::create()
-            ->setTag("hitbox_margin", new IntTag($this->hitboxMargin))
-            ->setTag(
-                "reach",
-                CompoundTag::create()
-                ->setTag("min", new IntTag($this->min))
-                ->setTag("max", new IntTag($this->max))
-            );
+        $nbt = CompoundTag::create()
+            ->setTag("hitbox_margin", new FloatTag($this->hitboxMargin))
+            ->setTag("reach", $this->reach->toNBT());
+
+        if ($this->creativeReach !== null) {
+            $nbt->setTag("creative_reach", $this->creativeReach->toNBT());
+        }
+
+        return $nbt;
     }
 }

--- a/src/Items/Components/DataDriven/ProjectileItemComponent.php
+++ b/src/Items/Components/DataDriven/ProjectileItemComponent.php
@@ -11,13 +11,20 @@ use pocketmine\nbt\tag\StringTag;
 class ProjectileItemComponent extends DataDrivenItemComponent
 {
     /**
+     * @param string $projectileEntity
      * @param float $minimumCriticalPower
-     * @param string $entity
      */
     public function __construct(
-        private readonly string $entity = "",
-        private readonly float $minimumCriticalPower = 1.25,
+        private readonly string $projectileEntity,
+        private readonly float $minimumCriticalPower = 0.0,
     ) {
+        if ($projectileEntity === "") {
+            throw new \InvalidArgumentException("Projectile entity identifier cannot be empty.");
+        }
+
+        if ($minimumCriticalPower < 0.0) {
+            throw new \InvalidArgumentException("Minimum critical power cannot be negative.");
+        }
     }
 
     /**
@@ -38,7 +45,7 @@ class ProjectileItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("projectile_entity", new StringTag($this->entity))
+            ->setTag("projectile_entity", new StringTag($this->projectileEntity))
             ->setTag("minimum_critical_power", new FloatTag($this->minimumCriticalPower));
     }
 }

--- a/src/Items/Components/DataDriven/Property/AllowOffHandProperty.php
+++ b/src/Items/Components/DataDriven/Property/AllowOffHandProperty.php
@@ -28,6 +28,6 @@ class AllowOffHandProperty extends PropertyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/CanDestroyInCreative.php
+++ b/src/Items/Components/DataDriven/Property/CanDestroyInCreative.php
@@ -28,6 +28,6 @@ class CanDestroyInCreative extends PropertyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/FoilProperty.php
+++ b/src/Items/Components/DataDriven/Property/FoilProperty.php
@@ -5,6 +5,7 @@ namespace Nexly\Items\Components\DataDriven\Property;
 use Attribute;
 use pocketmine\nbt\tag\ByteTag;
 
+/** @deprecated Use GlintProperty. */
 #[Attribute(Attribute::TARGET_CLASS)]
 class FoilProperty extends PropertyItemComponent
 {
@@ -28,6 +29,6 @@ class FoilProperty extends PropertyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/GlintProperty.php
+++ b/src/Items/Components/DataDriven/Property/GlintProperty.php
@@ -28,6 +28,6 @@ class GlintProperty extends PropertyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/HandEquippedProperty.php
+++ b/src/Items/Components/DataDriven/Property/HandEquippedProperty.php
@@ -28,6 +28,6 @@ class HandEquippedProperty extends PropertyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/IconProperty.php
+++ b/src/Items/Components/DataDriven/Property/IconProperty.php
@@ -30,13 +30,6 @@ class IconProperty extends PropertyItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("texture", new StringTag($this->icon))
-            ->setTag(
-                "textures",
-                CompoundTag::create()
-                ->setTag("default", new StringTag($this->icon))
-                ->setTag("dyed", new StringTag($this->icon . ".dyed"))
-                ->setTag("icon_trim", new StringTag($this->icon . ".trim"))
-            );
+            ->setTag("textures", CompoundTag::create()->setTag("default", new StringTag($this->icon)));
     }
 }

--- a/src/Items/Components/DataDriven/Property/InteractButtonProperty.php
+++ b/src/Items/Components/DataDriven/Property/InteractButtonProperty.php
@@ -29,6 +29,6 @@ class InteractButtonProperty extends PropertyItemComponent
      */
     public function toNBT(): StringTag|ByteTag
     {
-        return is_string($this->value) ? new StringTag($this->value) : new ByteTag($this->value);
+        return is_string($this->value) ? new StringTag($this->value) : new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/IsHiddenInCommandsProperty.php
+++ b/src/Items/Components/DataDriven/Property/IsHiddenInCommandsProperty.php
@@ -20,7 +20,7 @@ class IsHiddenInCommandsProperty extends PropertyItemComponent
      */
     public static function getName(): string
     {
-        return PropertyComponentIds::ALLOW_OFF_HAND->getValue();
+        return PropertyComponentIds::IS_HIDDEN_IN_COMMANDS->getValue();
     }
 
     /**
@@ -28,6 +28,6 @@ class IsHiddenInCommandsProperty extends PropertyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/LiquidClippedProperty.php
+++ b/src/Items/Components/DataDriven/Property/LiquidClippedProperty.php
@@ -28,6 +28,6 @@ class LiquidClippedProperty extends PropertyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/MaxStackSizeProperty.php
+++ b/src/Items/Components/DataDriven/Property/MaxStackSizeProperty.php
@@ -20,7 +20,7 @@ class MaxStackSizeProperty extends PropertyItemComponent
      */
     public static function getName(): string
     {
-        return PropertyComponentIds::MAX_STACk_SIZE->getValue();
+        return PropertyComponentIds::MAX_STACK_SIZE->getValue();
     }
 
     /**

--- a/src/Items/Components/DataDriven/Property/OnUseProperty.php
+++ b/src/Items/Components/DataDriven/Property/OnUseProperty.php
@@ -29,6 +29,6 @@ class OnUseProperty extends PropertyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/PropertyComponentIds.php
+++ b/src/Items/Components/DataDriven/Property/PropertyComponentIds.php
@@ -14,7 +14,7 @@ enum PropertyComponentIds: string
     case HAND_EQUIPPED = "hand_equipped";
     case IS_HIDDEN_IN_COMMANDS = "is_hidden_in_commands";
     case LIQUID_CLIPPED = "liquid_clipped";
-    case MAX_STACk_SIZE = "max_stack_size";
+    case MAX_STACK_SIZE = "max_stack_size";
     case MINING_SPEED = "mining_speed";
     case SHOULD_DESPAWN = "should_despawn";
     case STACKED_BY_DATA = "stacked_by_data";

--- a/src/Items/Components/DataDriven/Property/ShouldDespawnProperty.php
+++ b/src/Items/Components/DataDriven/Property/ShouldDespawnProperty.php
@@ -28,6 +28,6 @@ class ShouldDespawnProperty extends PropertyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/StackedByDataProperty.php
+++ b/src/Items/Components/DataDriven/Property/StackedByDataProperty.php
@@ -28,6 +28,6 @@ class StackedByDataProperty extends PropertyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/DataDriven/Property/UseAnimationProperty.php
+++ b/src/Items/Components/DataDriven/Property/UseAnimationProperty.php
@@ -26,8 +26,8 @@ class UseAnimationProperty extends PropertyItemComponent
     public static function fromItem(Item $item): UseAnimationProperty
     {
         return new self(match (true) {
-            $item instanceof Consumable => ItemAnimation::EAT,
             $item instanceof Potion => ItemAnimation::DRINK,
+            $item instanceof Consumable => ItemAnimation::EAT,
             default => ItemAnimation::NONE,
         });
     }

--- a/src/Items/Components/DataDriven/Property/UseDurationProperty.php
+++ b/src/Items/Components/DataDriven/Property/UseDurationProperty.php
@@ -5,6 +5,10 @@ namespace Nexly\Items\Components\DataDriven\Property;
 use Attribute;
 use pocketmine\nbt\tag\IntTag;
 
+/**
+ * @deprecated Use UseModifiersItemComponent. The minecraft:use_duration
+ *             component is no longer supported by current Bedrock versions.
+ */
 #[Attribute(Attribute::TARGET_CLASS)]
 class UseDurationProperty extends PropertyItemComponent
 {

--- a/src/Items/Components/DataDriven/PublisherOnUseOnItemComponent.php
+++ b/src/Items/Components/DataDriven/PublisherOnUseOnItemComponent.php
@@ -6,6 +6,10 @@ use Attribute;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
 
+/**
+ * @deprecated Internal client metadata, not a supported behavior-pack
+ *             component in the stable Microsoft item schema.
+ */
 #[Attribute(Attribute::TARGET_CLASS)]
 class PublisherOnUseOnItemComponent extends DataDrivenItemComponent
 {
@@ -32,6 +36,6 @@ class PublisherOnUseOnItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("autoSucceedOnClient", new ByteTag($this->autoSucceedOnClient));
+            ->setTag("autoSucceedOnClient", new ByteTag($this->autoSucceedOnClient ? 1 : 0));
     }
 }

--- a/src/Items/Components/DataDriven/RecordItemComponent.php
+++ b/src/Items/Components/DataDriven/RecordItemComponent.php
@@ -4,6 +4,7 @@ namespace Nexly\Items\Components\DataDriven;
 
 use Attribute;
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\StringTag;
 
@@ -11,15 +12,22 @@ use pocketmine\nbt\tag\StringTag;
 class RecordItemComponent extends DataDrivenItemComponent
 {
     /**
-     * @param string $sound
-     * @param int $duration
-     * @param int $signal
+     * @param string $soundEvent
+     * @param float $duration
+     * @param int $comparatorSignal
      */
     public function __construct(
-        private readonly string $sound,
-        private readonly int $duration = 20,
-        private readonly int $signal = 1
+        private readonly string $soundEvent,
+        private readonly float $duration = 0.0,
+        private readonly int $comparatorSignal = 1
     ) {
+        if ($duration < 0.0) {
+            throw new \InvalidArgumentException("Record duration cannot be negative.");
+        }
+
+        if ($comparatorSignal < 1 || $comparatorSignal > 13) {
+            throw new \InvalidArgumentException("Comparator signal must be between 1 and 13.");
+        }
     }
 
     /**
@@ -40,8 +48,8 @@ class RecordItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("sound_event", new StringTag($this->sound))
-            ->setTag("duration", new IntTag($this->duration))
-            ->setTag("comparator_signal", new IntTag($this->signal));
+            ->setTag("sound_event", new StringTag($this->soundEvent))
+            ->setTag("duration", new FloatTag($this->duration))
+            ->setTag("comparator_signal", new IntTag($this->comparatorSignal));
     }
 }

--- a/src/Items/Components/DataDriven/RenderOffsetsItemComponent.php
+++ b/src/Items/Components/DataDriven/RenderOffsetsItemComponent.php
@@ -40,12 +40,8 @@ class RenderOffsetsItemComponent extends DataDrivenItemComponent
         $offhand_fp  = round(0.065  * 16 / $this->resolution, 8);
         $mainHand_tp = $offhand_tp = round(0.0965 * 16 / $this->resolution, 8);
 
-        $scale = function (float $s): ListTag {
-            return new ListTag([
-                new FloatTag($s),
-                new FloatTag($s),
-                new FloatTag($s),
-            ]);
+        $scale = static function (float $s): ListTag {
+            return new ListTag([new FloatTag($s), new FloatTag($s), new FloatTag($s)]);
         };
 
         return CompoundTag::create()

--- a/src/Items/Components/DataDriven/RepairableItemComponent.php
+++ b/src/Items/Components/DataDriven/RepairableItemComponent.php
@@ -14,10 +14,10 @@ class RepairableItemComponent extends DataDrivenItemComponent
     public const VANILLA_COST_FORMULE = "math.min(q.remaining_durability + c.other->q.remaining_durability + math.floor(q.max_durability /20), c.other->q.max_durability)";
 
     /**
-     * @param ItemRepair[] $items
+     * @param list<ItemRepair> $repairItems
      */
     public function __construct(
-        private readonly array $items,
+        private readonly array $repairItems,
     ) {
     }
 
@@ -39,9 +39,6 @@ class RepairableItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("repair_items", new ListTag(
-                array_map(fn (ItemRepair $item) => $item->toNBT(), $this->items),
-                NBT::TAG_Compound
-            ));
+            ->setTag("repair_items", new ListTag(array_map(fn (ItemRepair $item): CompoundTag => $item->toNBT(), $this->repairItems), NBT::TAG_Compound));
     }
 }

--- a/src/Items/Components/DataDriven/ShooterItemComponent.php
+++ b/src/Items/Components/DataDriven/ShooterItemComponent.php
@@ -14,17 +14,20 @@ use pocketmine\nbt\tag\ListTag;
 class ShooterItemComponent extends DataDrivenItemComponent
 {
     /**
-     * @param array $ammunitions
+     * @param list<ItemAmmunition> $ammunition
      * @param bool $chargeOnDraw
      * @param float $maxDrawDuration
      * @param bool $scalePowerByDrawDuration
      */
     public function __construct(
-        private readonly array $ammunitions = [],
+        private readonly array $ammunition = [],
         private readonly bool  $chargeOnDraw = false,
         private readonly float $maxDrawDuration = 0.0,
-        private readonly bool  $scalePowerByDrawDuration = true
+        private readonly bool  $scalePowerByDrawDuration = false
     ) {
+        if ($maxDrawDuration < 0.0) {
+            throw new \InvalidArgumentException("Maximum draw duration cannot be negative.");
+        }
     }
 
     /**
@@ -45,9 +48,9 @@ class ShooterItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("charge_on_draw", new ByteTag($this->chargeOnDraw))
+            ->setTag("charge_on_draw", new ByteTag($this->chargeOnDraw ? 1 : 0))
             ->setTag("max_draw_duration", new FloatTag($this->maxDrawDuration))
-            ->setTag("scale_power_by_draw_duration", new ByteTag($this->scalePowerByDrawDuration))
-            ->setTag("ammunition", new ListTag(array_map(fn (ItemAmmunition $ammunition) => $ammunition->toNBT(), $this->ammunitions), NBT::TAG_Compound));
+            ->setTag("scale_power_by_draw_duration", new ByteTag($this->scalePowerByDrawDuration ? 1 : 0))
+            ->setTag("ammunition", new ListTag(array_map(fn (ItemAmmunition $ammunition): CompoundTag => $ammunition->toNBT(), $this->ammunition), NBT::TAG_Compound));
     }
 }

--- a/src/Items/Components/DataDriven/StorageItemComponent.php
+++ b/src/Items/Components/DataDriven/StorageItemComponent.php
@@ -16,38 +16,48 @@ use pocketmine\network\mcpe\convert\TypeConverter;
 class StorageItemComponent extends DataDrivenItemComponent
 {
     /**
-     * @param int $capacity
-     * @param bool $allowNested
-     * @param array $allowedItems
-     * @param array $bannedItems
+     * @param int $maxSlots
+     * @param bool $allowNestedStorageItems
+     * @param list<string> $allowedItems
+     * @param list<string> $bannedItems
      */
     public function __construct(
-        private readonly int $capacity,
-        private readonly bool $allowNested = true,
+        private readonly int $maxSlots = 64,
+        private readonly bool $allowNestedStorageItems = true,
         private readonly array $allowedItems = [],
         private readonly array $bannedItems = [],
     ) {
-        if ($this->capacity < 0) {
-            throw new \InvalidArgumentException("Capacity must be a non-negative integer.");
+        if ($this->maxSlots < 0) {
+            throw new \InvalidArgumentException("Maximum slots cannot be negative.");
         }
 
-        if ($this->capacity > 64) {
-            throw new \InvalidArgumentException("Capacity must not exceed 64.");
+        if ($this->maxSlots > 64) {
+            throw new \InvalidArgumentException("Maximum slots must not exceed 64.");
+        }
+
+        if ($this->allowedItems !== [] && $this->bannedItems !== []) {
+            throw new \InvalidArgumentException("Allowed and banned item filters cannot be used together.");
+        }
+
+        foreach ([...$allowedItems, ...$bannedItems] as $item) {
+            if ($item === "") {
+                throw new \InvalidArgumentException("Storage item filters must contain non-empty item identifiers.");
+            }
         }
     }
 
     /**
      * Create a StorageItemComponent.
      *
-     * @param int $capacity
-     * @param bool $allowNested
-     * @param Item[] $allowedItems
-     * @param Item[] $bannedItems
+     * @param int $maxSlots
+     * @param bool $allowNestedStorageItems
+     * @param list<Item> $allowedItems
+     * @param list<Item> $bannedItems
      * @return self
      */
     public static function from(
-        int $capacity,
-        bool $allowNested = true,
+        int $maxSlots,
+        bool $allowNestedStorageItems = true,
         array $allowedItems = [],
         array $bannedItems = []
     ): self {
@@ -58,8 +68,8 @@ class StorageItemComponent extends DataDrivenItemComponent
         };
 
         return new self(
-            $capacity,
-            $allowNested,
+            $maxSlots,
+            $allowNestedStorageItems,
             array_map($processItem, $allowedItems),
             array_map($processItem, $bannedItems)
         );
@@ -83,9 +93,9 @@ class StorageItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("max_slots", new IntTag($this->capacity))
-            ->setTag("allow_nested_storage_items", new ByteTag($this->allowNested))
-            ->setTag("allowed_items", new ListTag(array_map(fn (string $item) => new StringTag($item), $this->allowedItems), NBT::TAG_String))
-            ->setTag("banned_items", new ListTag(array_map(fn (string $item) => new StringTag($item), $this->bannedItems), NBT::TAG_String));
+            ->setTag("max_slots", new IntTag($this->maxSlots))
+            ->setTag("allow_nested_storage_items", new ByteTag($this->allowNestedStorageItems ? 1 : 0))
+            ->setTag("allowed_items", new ListTag(array_map(fn (string $item): StringTag => new StringTag($item), $this->allowedItems), NBT::TAG_String))
+            ->setTag("banned_items", new ListTag(array_map(fn (string $item): StringTag => new StringTag($item), $this->bannedItems), NBT::TAG_String));
     }
 }

--- a/src/Items/Components/DataDriven/StorageWeightLimitItemComponent.php
+++ b/src/Items/Components/DataDriven/StorageWeightLimitItemComponent.php
@@ -10,17 +10,13 @@ use pocketmine\nbt\tag\IntTag;
 class StorageWeightLimitItemComponent extends DataDrivenItemComponent
 {
     /**
-     * @param int $capacity
+     * @param int $maxWeightLimit
      */
     public function __construct(
-        private readonly int $capacity,
+        private readonly int $maxWeightLimit = 64,
     ) {
-        if ($capacity < 0) {
-            throw new \InvalidArgumentException("Capacity must be a non-negative integer.");
-        }
-
-        if ($capacity > 64) {
-            throw new \InvalidArgumentException("Capacity cannot exceed 64.");
+        if ($maxWeightLimit < 0 || $maxWeightLimit > 64) {
+            throw new \InvalidArgumentException("Weight limit must be between 0 and 64.");
         }
     }
 
@@ -42,6 +38,6 @@ class StorageWeightLimitItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("max_weight_limit", new IntTag($this->capacity));
+            ->setTag("max_weight_limit", new IntTag($this->maxWeightLimit));
     }
 }

--- a/src/Items/Components/DataDriven/StorageWeightModifierItemComponent.php
+++ b/src/Items/Components/DataDriven/StorageWeightModifierItemComponent.php
@@ -10,17 +10,13 @@ use pocketmine\nbt\tag\IntTag;
 class StorageWeightModifierItemComponent extends DataDrivenItemComponent
 {
     /**
-     * @param int $capacity
+     * @param int $weightInStorageItem
      */
     public function __construct(
-        private readonly int $capacity,
+        private readonly int $weightInStorageItem = 4,
     ) {
-        if ($capacity < 0) {
-            throw new \InvalidArgumentException("Capacity must be a non-negative integer.");
-        }
-
-        if ($capacity > 64) {
-            throw new \InvalidArgumentException("Capacity cannot exceed 64.");
+        if ($weightInStorageItem < 0) {
+            throw new \InvalidArgumentException("Storage weight cannot be negative.");
         }
     }
 
@@ -42,6 +38,6 @@ class StorageWeightModifierItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("weight_in_storage_item", new IntTag($this->capacity));
+            ->setTag("weight_in_storage_item", new IntTag($this->weightInStorageItem));
     }
 }

--- a/src/Items/Components/DataDriven/SwingDurationItemComponent.php
+++ b/src/Items/Components/DataDriven/SwingDurationItemComponent.php
@@ -9,7 +9,6 @@ use pocketmine\nbt\tag\FloatTag;
 /**
  * @see https://learn.microsoft.com/en-us/minecraft/creator/reference/content/itemreference/examples/itemcomponents/minecraft_swing_duration?view=minecraft-bedrock-stable
  * @since 1.21.120
- * @internal
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 class SwingDurationItemComponent extends DataDrivenItemComponent
@@ -18,8 +17,11 @@ class SwingDurationItemComponent extends DataDrivenItemComponent
      * @param float $duration The duration of the swing sound in seconds.
      */
     public function __construct(
-        private readonly float $duration,
+        private readonly float $duration = 0.3,
     ) {
+        if ($duration < 0.0) {
+            throw new \InvalidArgumentException("Swing duration cannot be negative.");
+        }
     }
 
     /**

--- a/src/Items/Components/DataDriven/SwingSoundsItemComponent.php
+++ b/src/Items/Components/DataDriven/SwingSoundsItemComponent.php
@@ -9,7 +9,6 @@ use pocketmine\nbt\tag\StringTag;
 /**
  * @see https://learn.microsoft.com/en-us/minecraft/creator/reference/content/itemreference/examples/itemcomponents/minecraft_swing_sounds?view=minecraft-bedrock-stable
  * @since 1.21.120
- * @internal
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 class SwingSoundsItemComponent extends DataDrivenItemComponent

--- a/src/Items/Components/DataDriven/TagsItemComponent.php
+++ b/src/Items/Components/DataDriven/TagsItemComponent.php
@@ -12,11 +12,16 @@ use pocketmine\nbt\tag\StringTag;
 class TagsItemComponent extends DataDrivenItemComponent
 {
     /**
-     * @param array $tags
+     * @param list<string> $tags
      */
     public function __construct(
         private readonly array $tags,
     ) {
+        foreach ($tags as $tag) {
+            if ($tag === "") {
+                throw new \InvalidArgumentException("Item tags must contain only non-empty strings.");
+            }
+        }
     }
 
     /**
@@ -37,6 +42,6 @@ class TagsItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("tags", new ListTag(array_map(fn ($tag) => new StringTag($tag), $this->tags), NBT::TAG_String));
+            ->setTag("tags", new ListTag(array_map(fn (string $tag): StringTag => new StringTag($tag), $this->tags), NBT::TAG_String));
     }
 }

--- a/src/Items/Components/DataDriven/ThrowableItemComponent.php
+++ b/src/Items/Components/DataDriven/ThrowableItemComponent.php
@@ -19,13 +19,25 @@ class ThrowableItemComponent extends DataDrivenItemComponent
      * @param bool $scalePowerByDrawDuration
      */
     public function __construct(
-        private readonly bool  $doSwingAnimation = true,
+        private readonly bool  $doSwingAnimation = false,
         private readonly float $launchPowerScale = 1.0,
         private readonly float $maxDrawDuration = 0.0,
         private readonly float $maxLaunchPower = 1.0,
         private readonly float $minDrawDuration = 0.0,
         private readonly bool  $scalePowerByDrawDuration = false
     ) {
+        if (
+            $launchPowerScale < 0.0
+            || $maxDrawDuration < 0.0
+            || $maxLaunchPower < 0.0
+            || $minDrawDuration < 0.0
+        ) {
+            throw new \InvalidArgumentException("Throwable power and duration values cannot be negative.");
+        }
+
+        if ($minDrawDuration > $maxDrawDuration) {
+            throw new \InvalidArgumentException("Minimum draw duration cannot exceed maximum draw duration.");
+        }
     }
 
     /**
@@ -46,11 +58,11 @@ class ThrowableItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
-            ->setTag("do_swing_animation", new ByteTag($this->doSwingAnimation))
+            ->setTag("do_swing_animation", new ByteTag($this->doSwingAnimation ? 1 : 0))
             ->setTag("launch_power_scale", new FloatTag($this->launchPowerScale))
             ->setTag("max_draw_duration", new FloatTag($this->maxDrawDuration))
             ->setTag("max_launch_power", new FloatTag($this->maxLaunchPower))
             ->setTag("min_draw_duration", new FloatTag($this->minDrawDuration))
-            ->setTag("scale_power_by_draw_duration", new ByteTag($this->scalePowerByDrawDuration));
+            ->setTag("scale_power_by_draw_duration", new ByteTag($this->scalePowerByDrawDuration ? 1 : 0));
     }
 }

--- a/src/Items/Components/DataDriven/Types/DurabilityThreshold.php
+++ b/src/Items/Components/DataDriven/Types/DurabilityThreshold.php
@@ -10,9 +10,12 @@ class DurabilityThreshold
 {
     public function __construct(
         private readonly int $durability,
-        private readonly ?string $sound = null,
-        private readonly ?string $particle = null,
+        private readonly ?string $soundEvent = null,
+        private readonly ?string $particleType = null,
     ) {
+        if ($durability < 0) {
+            throw new \InvalidArgumentException("Durability threshold cannot be negative.");
+        }
     }
 
     /**
@@ -28,7 +31,7 @@ class DurabilityThreshold
      */
     public function getSound(): ?string
     {
-        return $this->sound;
+        return $this->soundEvent;
     }
 
     /**
@@ -36,7 +39,7 @@ class DurabilityThreshold
      */
     public function getParticle(): ?string
     {
-        return $this->particle;
+        return $this->particleType;
     }
 
     /**
@@ -47,12 +50,12 @@ class DurabilityThreshold
         $nbt = CompoundTag::create()
             ->setTag("durability", new IntTag($this->durability));
 
-        if ($this->sound !== null) {
-            $nbt->setTag("sound", new StringTag($this->sound));
+        if ($this->soundEvent !== null) {
+            $nbt->setTag("sound_event", new StringTag($this->soundEvent));
         }
 
-        if ($this->particle !== null) {
-            $nbt->setTag("particle", new StringTag($this->particle));
+        if ($this->particleType !== null) {
+            $nbt->setTag("particle_type", new StringTag($this->particleType));
         }
 
         return $nbt;

--- a/src/Items/Components/DataDriven/Types/FloatRange.php
+++ b/src/Items/Components/DataDriven/Types/FloatRange.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Nexly\Items\Components\DataDriven\Types;
+
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\FloatTag;
+
+readonly class FloatRange
+{
+    public function __construct(
+        private float $min = 0.0,
+        private float $max = 0.0,
+    ) {
+        if ($min > $max) {
+            throw new \InvalidArgumentException("Range minimum cannot be greater than its maximum.");
+        }
+    }
+
+    public function getMin(): float
+    {
+        return $this->min;
+    }
+
+    public function getMax(): float
+    {
+        return $this->max;
+    }
+
+    public function toNBT(): CompoundTag
+    {
+        return CompoundTag::create()
+            ->setTag("min", new FloatTag($this->min))
+            ->setTag("max", new FloatTag($this->max));
+    }
+}

--- a/src/Items/Components/DataDriven/Types/ItemAmmunition.php
+++ b/src/Items/Components/DataDriven/Types/ItemAmmunition.php
@@ -12,10 +12,13 @@ class ItemAmmunition
 {
     public function __construct(
         private readonly string $item,
-        private readonly bool $searchInventory = true,
-        private readonly bool $useInCreative = true,
-        private readonly bool $useOffHand = true
+        private readonly bool $searchInventory = false,
+        private readonly bool $useInCreative = false,
+        private readonly bool $useOffHand = false
     ) {
+        if ($item === "") {
+            throw new \InvalidArgumentException("Ammunition item identifier cannot be empty.");
+        }
     }
 
     /**
@@ -27,27 +30,17 @@ class ItemAmmunition
      * @param bool $useOffHand
      * @return self
      */
-    public static function from(
-        Item $item,
-        bool $searchInventory = true,
-        bool $useInCreative = true,
-        bool $useOffHand = true
-    ): self {
+    public static function from(Item $item, bool $searchInventory = false, bool $useInCreative = false, bool $useOffHand = false): self {
         [$rid] = ($converter = TypeConverter::getInstance())->getItemTranslator()->toNetworkId($item);
-        return new self(
-            $converter->getItemTypeDictionary()->fromIntId($rid),
-            $searchInventory,
-            $useInCreative,
-            $useOffHand
-        );
+        return new self($converter->getItemTypeDictionary()->fromIntId($rid), $searchInventory, $useInCreative, $useOffHand);
     }
 
     public function toNBT(): CompoundTag
     {
         return CompoundTag::create()
             ->setTag("item", new StringTag($this->item))
-            ->setTag("search_inventory", new ByteTag($this->searchInventory))
-            ->setTag("use_in_creative", new ByteTag($this->useInCreative))
-            ->setTag("use_offhand", new ByteTag($this->useOffHand));
+            ->setTag("search_inventory", new ByteTag($this->searchInventory ? 1 : 0))
+            ->setTag("use_in_creative", new ByteTag($this->useInCreative ? 1 : 0))
+            ->setTag("use_offhand", new ByteTag($this->useOffHand ? 1 : 0));
     }
 }

--- a/src/Items/Components/DataDriven/Types/ItemCooldownAction.php
+++ b/src/Items/Components/DataDriven/Types/ItemCooldownAction.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Nexly\Items\Components\DataDriven\Types;
+
+enum ItemCooldownAction: string
+{
+    case USE = "use";
+    case ATTACK = "attack";
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Items/Components/DataDriven/Types/ItemRepair.php
+++ b/src/Items/Components/DataDriven/Types/ItemRepair.php
@@ -5,6 +5,7 @@ namespace Nexly\Items\Components\DataDriven\Types;
 use pocketmine\item\Item;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\StringTag;
@@ -13,33 +14,43 @@ use pocketmine\network\mcpe\convert\TypeConverter;
 class ItemRepair
 {
     /**
-     * @param float|string $amount
-     * @param string[] $items
+     * @param float|string $repairAmount
+     * @param list<string> $items
      */
     public function __construct(
-        private float|string   $amount,
+        private readonly float|string $repairAmount,
         private readonly array $items,
     ) {
-        if (is_double($this->amount)) {
-            $this->amount = strval($this->amount);
+        if ($repairAmount === "") {
+            throw new \InvalidArgumentException("Repair amount expression cannot be empty.");
+        }
+
+        if ($items === []) {
+            throw new \InvalidArgumentException("At least one repair item is required.");
+        }
+
+        foreach ($items as $item) {
+            if ($item === "") {
+                throw new \InvalidArgumentException("Repair items must be non-empty item identifiers.");
+            }
         }
     }
 
     /**
      * Create an ItemRepair component from an amount and a list of items.
      *
-     * @param float|string $amount
+     * @param float|string $repairAmount
      * @param Item ...$items
      * @return ItemRepair
      */
-    public static function from(float|string $amount, Item ...$items): ItemRepair
+    public static function from(float|string $repairAmount, Item ...$items): self
     {
         return new self(
-            $amount,
-            array_map(function (Item $item): string {
+            $repairAmount,
+            array_values(array_map(function (Item $item): string {
                 [$rid] = ($converter = TypeConverter::getInstance())->getItemTranslator()->toNetworkId($item);
                 return $converter->getItemTypeDictionary()->fromIntId($rid);
-            }, $items)
+            }, $items))
         );
     }
 
@@ -48,18 +59,19 @@ class ItemRepair
      */
     public function getAmount(): float|string
     {
-        return $this->amount;
+        return $this->repairAmount;
     }
 
     public function toNBT(): CompoundTag
     {
+        $repairAmount = is_float($this->repairAmount)
+            ? new FloatTag($this->repairAmount)
+            : CompoundTag::create()
+                ->setTag("expression", new StringTag($this->repairAmount))
+                ->setTag("version", new IntTag(12));
+
         return CompoundTag::create()
-            ->setTag(
-                "repair_amount",
-                CompoundTag::create()
-                ->setTag("expression", new StringTag($this->amount))
-                ->setTag("version", new IntTag(0))
-            )
-            ->setTag("items", new ListTag(array_map(fn (string $stringId) => new StringTag($stringId), $this->items), NBT::TAG_String));
+            ->setTag("repair_amount", $repairAmount)
+            ->setTag("items", new ListTag(array_map(fn (string $stringId): StringTag => new StringTag($stringId), $this->items), NBT::TAG_String));
     }
 }

--- a/src/Items/Components/DataDriven/Types/ItemSlot.php
+++ b/src/Items/Components/DataDriven/Types/ItemSlot.php
@@ -7,6 +7,7 @@ use pocketmine\inventory\ArmorInventory;
 enum ItemSlot: string
 {
     case ARMOR = "slot.armor";
+    case ARMOR_BODY = "slot.armor.body";
     case ARMOR_CHEST = "slot.armor.chest";
     case ARMOR_FEET = "slot.armor.feet";
     case ARMOR_HEAD = "slot.armor.head";
@@ -54,7 +55,7 @@ enum ItemSlot: string
             ArmorInventory::SLOT_HEAD => self::ARMOR_HEAD,
             ArmorInventory::SLOT_LEGS => self::ARMOR_LEGS,
             ArmorInventory::SLOT_FEET => self::ARMOR_FEET,
-            default => self::ARMOR
+            default => self::ARMOR_BODY
         };
     }
 }

--- a/src/Items/Components/DataDriven/Types/ItemStartUsing.php
+++ b/src/Items/Components/DataDriven/Types/ItemStartUsing.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Nexly\Items\Components\DataDriven\Types;
+
+enum ItemStartUsing: string
+{
+    case ALWAYS = "always";
+    case IF_FIRST = "if_first";
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Items/Components/DataDriven/Types/KineticEffectConditions.php
+++ b/src/Items/Components/DataDriven/Types/KineticEffectConditions.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nexly\Items\Components\DataDriven\Types;
+
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\FloatTag;
+use pocketmine\nbt\tag\IntTag;
+
+class KineticEffectConditions
+{
+    public function __construct(
+        private readonly int $maxDuration = -1,
+        private readonly float $minRelativeSpeed = 0.0,
+        private readonly float $minSpeed = 0.0,
+    ) {
+    }
+
+    public function toNBT(): CompoundTag
+    {
+        return CompoundTag::create()
+            ->setTag("max_duration", new IntTag($this->maxDuration))
+            ->setTag("min_relative_speed", new FloatTag($this->minRelativeSpeed))
+            ->setTag("min_speed", new FloatTag($this->minSpeed));
+    }
+}

--- a/src/Items/Components/DataDriven/UseModifiersItemComponent.php
+++ b/src/Items/Components/DataDriven/UseModifiersItemComponent.php
@@ -3,20 +3,36 @@
 namespace Nexly\Items\Components\DataDriven;
 
 use Attribute;
+use Nexly\Items\Components\DataDriven\Types\ItemStartUsing;
+use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\FloatTag;
+use pocketmine\nbt\tag\StringTag;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class UseModifiersItemComponent extends DataDrivenItemComponent
 {
     /**
-     * @param float $duration
+     * @param float $useDuration
      * @param float|null $movementModifier
+     * @param bool $emitVibrations
+     * @param string|null $startSound
+     * @param ItemStartUsing $startUsing
      */
     public function __construct(
-        private readonly float $duration,
+        private readonly float $useDuration,
         private readonly ?float $movementModifier = null,
+        private readonly bool $emitVibrations = true,
+        private readonly ?string $startSound = null,
+        private readonly ItemStartUsing $startUsing = ItemStartUsing::ALWAYS,
     ) {
+        if ($useDuration < 0.0) {
+            throw new \InvalidArgumentException("Use duration cannot be negative.");
+        }
+
+        if ($movementModifier !== null && ($movementModifier < 0.0 || $movementModifier > 1.0)) {
+            throw new \InvalidArgumentException("Movement modifier must be between 0 and 1.");
+        }
     }
 
     /**
@@ -37,10 +53,16 @@ class UseModifiersItemComponent extends DataDrivenItemComponent
     public function toNBT(): CompoundTag
     {
         $nbt = CompoundTag::create()
-            ->setTag("use_duration", new FloatTag($this->duration));
+            ->setTag("use_duration", new FloatTag($this->useDuration))
+            ->setTag("emit_vibrations", new ByteTag($this->emitVibrations ? 1 : 0))
+            ->setTag("start_using", new StringTag($this->startUsing->getValue()));
 
         if ($this->movementModifier !== null) {
             $nbt->setTag("movement_modifier", new FloatTag($this->movementModifier));
+        }
+
+        if ($this->startSound !== null) {
+            $nbt->setTag("start_sound", new StringTag($this->startSound));
         }
 
         return $nbt;

--- a/src/Items/Components/DataDriven/WearableItemComponent.php
+++ b/src/Items/Components/DataDriven/WearableItemComponent.php
@@ -4,6 +4,7 @@ namespace Nexly\Items\Components\DataDriven;
 
 use Attribute;
 use Nexly\Items\Components\DataDriven\Types\ItemSlot;
+use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\StringTag;
@@ -14,11 +15,30 @@ class WearableItemComponent extends DataDrivenItemComponent
     /**
      * @param ItemSlot $slot
      * @param int $protection
+     * @param bool $hidesPlayerLocation
+     * @param bool|null $dispensable
      */
     public function __construct(
         private readonly ItemSlot $slot,
-        private readonly int $protection
+        private readonly int $protection = 0,
+        private readonly bool $hidesPlayerLocation = false,
+        private readonly ?bool $dispensable = null,
     ) {
+        if ($protection < 0) {
+            throw new \InvalidArgumentException("Wearable protection cannot be negative.");
+        }
+
+        if (!in_array($slot, [
+            ItemSlot::ARMOR_BODY,
+            ItemSlot::ARMOR_CHEST,
+            ItemSlot::ARMOR_FEET,
+            ItemSlot::ARMOR_HEAD,
+            ItemSlot::ARMOR_LEGS,
+            ItemSlot::WEAPON_MAIN_HAND,
+            ItemSlot::WEAPON_OFF_HAND,
+        ], true)) {
+            throw new \InvalidArgumentException("Unsupported wearable equipment slot.");
+        }
     }
 
     /**
@@ -38,8 +58,15 @@ class WearableItemComponent extends DataDrivenItemComponent
      */
     public function toNBT(): CompoundTag
     {
-        return CompoundTag::create()
+        $nbt = CompoundTag::create()
             ->setTag("slot", new StringTag($this->slot->getValue()))
-            ->setTag("protection", new IntTag($this->protection));
+            ->setTag("protection", new IntTag($this->protection))
+            ->setTag("hides_player_location", new ByteTag($this->hidesPlayerLocation ? 1 : 0));
+
+        if ($this->dispensable !== null) {
+            $nbt->setTag("dispensable", new ByteTag($this->dispensable ? 1 : 0));
+        }
+
+        return $nbt;
     }
 }

--- a/src/Items/Components/Legacy/FoilComponent.php
+++ b/src/Items/Components/Legacy/FoilComponent.php
@@ -30,6 +30,6 @@ class FoilComponent extends LegacyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/Legacy/FoodComponent.php
+++ b/src/Items/Components/Legacy/FoodComponent.php
@@ -37,9 +37,9 @@ class FoodComponent extends LegacyItemComponent
      * @param int $cooldownTick
      * @param string $usingConvertsTo
      * @param LegacyItemUseActionType $useActionType
-     * @param float[] $onUseRange
-     * @param LegacyEffect[] $effects
-     * @param int[] $removeEffects
+     * @param list<float> $onUseRange
+     * @param list<LegacyEffect> $effects
+     * @param list<int> $removeEffects
      */
     public function __construct(
         private readonly int                     $nutrition,
@@ -63,7 +63,7 @@ class FoodComponent extends LegacyItemComponent
     public function setUsingConvertsTo(Item $item): void
     {
         [$rId] = ($converter = TypeConverter::getInstance())->getItemTranslator()->toNetworkId($item);
-        if ($rId == null) {
+        if ($rId === null) {
             throw new \InvalidArgumentException("Item does not have a valid network ID");
         }
 
@@ -77,16 +77,21 @@ class FoodComponent extends LegacyItemComponent
      */
     public function toNBT(): CompoundTag
     {
+        $cooldownType = is_string($this->cooldownType) ? $this->cooldownType : $this->cooldownType->value;
+        if (!is_string($cooldownType)) {
+            throw new \InvalidArgumentException("The cooldown type enum must be backed by a string.");
+        }
+
         return CompoundTag::create()
             ->setTag("nutrition", new IntTag($this->nutrition))
             ->setTag("saturation_modifier", new FloatTag($this->saturationModifier))
-            ->setTag("can_always_eat", new ByteTag($this->canAlwaysEat))
-            ->setTag("cooldown_type", new StringTag(is_string($this->cooldownType) ? $this->cooldownType : $this->cooldownType->value))
+            ->setTag("can_always_eat", new ByteTag($this->canAlwaysEat ? 1 : 0))
+            ->setTag("cooldown_type", new StringTag($cooldownType))
             ->setTag("cooldown_time", new IntTag($this->cooldownTick))
             ->setTag("using_converts_to", CompoundTag::create()->setTag("name", new StringTag($this->usingConvertsTo)))
             ->setTag("on_use_action", new IntTag($this->useActionType->getValue()))
-            ->setTag("on_use_range", new ListTag(array_map(fn (float $value) => new FloatTag($value), $this->onUseRange), NBT::TAG_Float))
-            ->setTag("effects", new ListTag(array_map(fn (LegacyEffect $effect) => $effect->toNBT(), $this->effects), NBT::TAG_Compound))
-            ->setTag("remove_effects", new ListTag(array_map(fn (int $value) => new IntTag($value), $this->removeEffects), NBT::TAG_Int));
+            ->setTag("on_use_range", new ListTag(array_map(fn (float $value): FloatTag => new FloatTag($value), $this->onUseRange), NBT::TAG_Float))
+            ->setTag("effects", new ListTag(array_map(fn (LegacyEffect $effect): CompoundTag => $effect->toNBT(), $this->effects), NBT::TAG_Compound))
+            ->setTag("remove_effects", new ListTag(array_map(fn (int $value): IntTag => new IntTag($value), $this->removeEffects), NBT::TAG_Int));
     }
 }

--- a/src/Items/Components/Legacy/HandEquippedComponent.php
+++ b/src/Items/Components/Legacy/HandEquippedComponent.php
@@ -30,6 +30,6 @@ class HandEquippedComponent extends LegacyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/Legacy/LegacyItemBuilder.php
+++ b/src/Items/Components/Legacy/LegacyItemBuilder.php
@@ -111,7 +111,7 @@ class LegacyItemBuilder extends ItemBuilder
         if ($item instanceof ConsumableItem) {
             if ($item instanceof FoodSource) {
                 $this->addComponent(new FoodComponent(
-                    $item->getFoodRestore(),
+                    (int) round($item->getFoodRestore()),
                     $item->getSaturationRestore(),
                     !$item->requiresHunger(),
                     cooldownType: $item->getCooldownTag() ?? $this->getStringId(),
@@ -119,7 +119,7 @@ class LegacyItemBuilder extends ItemBuilder
                 ));
             } else {
                 $this->addComponent(new FoodComponent(
-                    0.0,
+                    0,
                     0.0,
                     true,
                     cooldownType: $item->getCooldownTag() ?? $this->getStringId(),

--- a/src/Items/Components/Legacy/SeedComponent.php
+++ b/src/Items/Components/Legacy/SeedComponent.php
@@ -36,17 +36,23 @@ class SeedComponent extends LegacyItemComponent
     {
         return new self(
             GlobalBlockStateHandlers::getSerializer()->serialize($result->getStateId())->getName(),
-            array_map(fn (Block $block) => GlobalBlockStateHandlers::getSerializer()->serialize($block->getStateId())->getName(), $blocks),
+            array_values(array_map(
+                fn (Block $block): string => GlobalBlockStateHandlers::getSerializer()->serialize($block->getStateId())->getName(),
+                $blocks
+            )),
         );
     }
 
+    /**
+     * @param list<string> $plantAt
+     */
     public function __construct(
         private string $result,
         private array $plantAt = [],
         private readonly LegacyFace $plantFace = LegacyFace::UP,
     ) {
         $this->result = str_replace(["minecraft:", "grass_block", "air"], ["", "grass", "light_block"], strtolower($this->result));
-        $this->plantAt = array_map(fn (string $block) => str_replace(["minecraft:", "grass_block"], ["", "grass"], strtolower($block)), $this->plantAt);
+        $this->plantAt = array_map(fn (string $block): string => str_replace(["minecraft:", "grass_block"], ["", "grass"], strtolower($block)), $this->plantAt);
     }
 
     /**
@@ -59,7 +65,7 @@ class SeedComponent extends LegacyItemComponent
         return CompoundTag::create()
             ->setTag("crop_result", new StringTag($this->result))
             ->setTag("plant_at_face", new StringTag($this->plantFace->getValue()))
-            ->setTag("plant_at_any_solid_surface", new ByteTag(empty($this->plantAt)))
-            ->setTag("plant_at", new ListTag(array_map(fn (string $block) => new StringTag($block), $this->plantAt), NBT::TAG_String));
+            ->setTag("plant_at_any_solid_surface", new ByteTag(empty($this->plantAt) ? 1 : 0))
+            ->setTag("plant_at", new ListTag(array_map(fn (string $block): StringTag => new StringTag($block), $this->plantAt), NBT::TAG_String));
     }
 }

--- a/src/Items/Components/Legacy/StackedByDataComponent.php
+++ b/src/Items/Components/Legacy/StackedByDataComponent.php
@@ -15,7 +15,7 @@ class StackedByDataComponent extends LegacyItemComponent
      */
     public static function getName(): string
     {
-        return LegacyComponentIds::HAND_EQUIPPED->getValue();
+        return LegacyComponentIds::STACKED_BY_DATA->getValue();
     }
 
     public function __construct(
@@ -30,6 +30,6 @@ class StackedByDataComponent extends LegacyItemComponent
      */
     public function toNBT(): ByteTag
     {
-        return new ByteTag($this->value);
+        return new ByteTag($this->value ? 1 : 0);
     }
 }

--- a/src/Items/Components/Legacy/Types/LegacyEffect.php
+++ b/src/Items/Components/Legacy/Types/LegacyEffect.php
@@ -4,6 +4,7 @@ namespace Nexly\Items\Components\Legacy\Types;
 
 use pocketmine\data\bedrock\EffectIdMap;
 use pocketmine\entity\effect\EffectInstance;
+use pocketmine\lang\Translatable;
 use pocketmine\nbt\tag\CompoundTag;
 
 class LegacyEffect
@@ -36,9 +37,11 @@ class LegacyEffect
      */
     public static function from(EffectInstance $effectInstance): self
     {
+        $name = $effectInstance->getType()->getName();
+
         return new self(
             EffectIdMap::getInstance()->toId($effectInstance->getType()),
-            $effectInstance->getType()->getName(),
+            $name instanceof Translatable ? $name->getText() : $name,
             "", // Description ID is not available in EffectInstance
             $effectInstance->getDuration(),
             $effectInstance->getAmplifier(),

--- a/src/Items/Creative/NexlyCreative.php
+++ b/src/Items/Creative/NexlyCreative.php
@@ -41,6 +41,7 @@ use pocketmine\inventory\ArmorInventory;
 use pocketmine\inventory\CreativeCategory;
 use pocketmine\inventory\CreativeGroup as CreativeGroupPM;
 use pocketmine\inventory\CreativeInventory;
+use pocketmine\inventory\CreativeInventoryEntry;
 use pocketmine\item\Armor;
 use pocketmine\item\Arrow;
 use pocketmine\item\Axe;
@@ -55,16 +56,20 @@ use pocketmine\item\ItemBlock;
 use pocketmine\item\Pickaxe;
 use pocketmine\item\Record;
 use pocketmine\item\Shovel;
+use pocketmine\item\SpawnEgg;
 use pocketmine\item\SplashPotion;
 use pocketmine\item\Sword;
+use pocketmine\lang\Translatable;
 
 class NexlyCreative
 {
-    /** @var CreativeGroupPM[] */
+    /** @var array<string, CreativeGroupPM> */
     private static array $groups = [];
-    /** @var CreativeCategory[]  */
+
+    /** @var array<string, CreativeCategory> */
     private static array $groupToCategory = [];
-    /** @var CreativeGroup|\StringBackedEnum[]  */
+
+    /** @var array<string, CreativeInventoryEntry|CreativeGroupPM> */
     private static array $categoryToGroups = [];
 
     /**
@@ -88,9 +93,12 @@ class NexlyCreative
                 continue;
             }
 
-            self::$groups[$group->getName()?->getText() ?? $group->getName()] = $group;
+            $name = $group->getName();
+            $groupName = $name instanceof Translatable ? $name->getText() : $name;
+
+            self::$groups[$groupName] = $group;
             self::$categoryToGroups[$category->name] = $entry;
-            self::$groupToCategory[$group->getName()?->getText()] = $category;
+            self::$groupToCategory[$groupName] = $category;
         }
     }
 
@@ -102,22 +110,23 @@ class NexlyCreative
      * @param CreativeGroup|BackedEnum|null $group
      * @return void
      */
-    public static function add(Item $item, CreativeCategory $category = null, CreativeGroup|BackedEnum $group = null): void
+    public static function add(Item $item, ?CreativeCategory $category = null, CreativeGroup|BackedEnum|null $group = null): void
     {
         self::loadGroups(); // Ensure groups are loaded
 
+        $groupValue = $group === null ? null : self::getGroupValue($group);
         if ($category === null && $group !== null) {
-            $category = self::$groupToCategory[$group->getValue()];
+            $category = self::$groupToCategory[$groupValue] ?? null;
         }
         if ($category === null) {
             $category = $item instanceof ItemBlock ? CreativeCategory::CONSTRUCTION : CreativeCategory::ITEMS;
         }
 
         $pm = null;
-        if ($group !== null) {
-            $pm = self::$groups[$group->value] ??= new CreativeGroupPM($group->value, $item);
+        if ($groupValue !== null) {
+            $pm = self::$groups[$groupValue] ??= new CreativeGroupPM($groupValue, $item);
             self::$categoryToGroups[$category->name] = $pm;
-            self::$groupToCategory[$group->value] = $category;
+            self::$groupToCategory[$groupValue] = $category;
         }
 
         CreativeInventory::getInstance()->add($item, $category, $pm);
@@ -179,7 +188,7 @@ class NexlyCreative
             $block instanceof Button => new CreativeInfo(null, CreativeGroup::GROUP_BUTTONS),
             $block instanceof Door => new CreativeInfo(null, CreativeGroup::GROUP_DOOR),
             $block instanceof Trapdoor => new CreativeInfo(null, CreativeGroup::GROUP_TRAPDOOR),
-            $block instanceof WallSign => new CreativeInfo(null, CreativeGroup::GROUP_HANDGING_SIGN),
+            $block instanceof WallSign => new CreativeInfo(null, CreativeGroup::GROUP_SIGN),
             $block instanceof BaseSign => new CreativeInfo(null, CreativeGroup::GROUP_SIGN),
             $block instanceof Chest => new CreativeInfo(null, CreativeGroup::GROUP_CHEST),
             $block instanceof Anvil => new CreativeInfo(null, CreativeGroup::GROUP_ANVIL),
@@ -202,5 +211,14 @@ class NexlyCreative
             $block instanceof NetherWartPlant => new CreativeInfo(CreativeCategory::NATURE, null),
             default => new CreativeInfo(CreativeCategory::CONSTRUCTION),
         };
+    }
+
+    private static function getGroupValue(BackedEnum $group): string
+    {
+        if (!is_string($group->value)) {
+            throw new \InvalidArgumentException("Creative group enum values must be strings.");
+        }
+
+        return $group->value;
     }
 }

--- a/src/Items/ItemBuilder.php
+++ b/src/Items/ItemBuilder.php
@@ -8,6 +8,7 @@ use Nexly\Items\Creative\NexlyCreative;
 use Nexly\Mappings\ItemMappings;
 use Nexly\Recipes\NexlyRecipes;
 use Nexly\Recipes\Types\Recipe;
+use pocketmine\block\BlockTypeIds;
 use pocketmine\data\bedrock\item\SavedItemData;
 use pocketmine\data\bedrock\item\upgrade\LegacyItemIdToStringIdMap;
 use pocketmine\item\Item;
@@ -45,7 +46,7 @@ abstract class ItemBuilder
      */
     public function setStringId(string $stringId): self
     {
-        if (str_contains("minecraft:", $stringId)) {
+        if (str_contains($stringId, "minecraft:")) {
             throw new \InvalidArgumentException("Custom item string ID cannot contain the 'minecraft:' namespace.");
         }
 
@@ -186,13 +187,19 @@ abstract class ItemBuilder
         }
 
         $item = $this->getItem();
-        ItemDataHandlers::getDeserializer()->map($this->getStringId(), $this->getDeserializer() ?? fn () => clone $item);
-        ItemDataHandlers::getSerializer()->map($item, $this->getSerializer() ?? fn () => new SavedItemData($this->getStringId()));
+        ItemDataHandlers::getDeserializer()->map(
+            $this->getStringId(),
+            $this->getDeserializer() ?? static fn (SavedItemData $data): Item => clone $item
+        );
+        ItemDataHandlers::getSerializer()->map(
+            $item,
+            $this->getSerializer() ?? fn (Item $item): SavedItemData => new SavedItemData($this->getStringId())
+        );
         ItemMappings::getInstance()->registerMapping($this, new ItemTypeEntry(
             $this->getStringId(),
             $this->getNumericId(),
-            $this->getVersion()->equals(ItemVersion::DATA_DRIVEN),
-            $this->getVersion()->getValue(),
+            self::getVersion()->equals(ItemVersion::DATA_DRIVEN),
+            self::getVersion()->getValue(),
             new CacheableNbt($this->toNBT())
         ));
 
@@ -202,7 +209,7 @@ abstract class ItemBuilder
             $identifier = $path;
         }
 
-        StringToItemParser::getInstance()->register($identifier, fn () => clone $item);
+        StringToItemParser::getInstance()->register($identifier, fn (): Item => clone $item);
         LegacyItemIdToStringIdMap::getInstance()->add($identifier, $item->getTypeId());
 
         $creativeInfo = $this->getCreativeInfo() ?? NexlyCreative::detectCreativeInfoFrom($item);
@@ -215,7 +222,7 @@ abstract class ItemBuilder
                 if ($instance instanceof CreativeInfo) {
                     $creativeInfo = $instance;
                 } elseif ($instance instanceof Recipe) {
-                    NexlyRecipes::getInstance()->addRecipe(fn () => $attribute->newInstance());
+                    NexlyRecipes::getInstance()->addRecipe(fn (): Recipe => $instance);
                 }
             }
         }

--- a/src/Items/NexlyItems.php
+++ b/src/Items/NexlyItems.php
@@ -20,7 +20,7 @@ class NexlyItems
      * @param CreativeInfo|null $creativeInfo
      * @return void
      */
-    public static function register(string $stringId, Item $item, CreativeInfo $creativeInfo = null): void
+    public static function register(string $stringId, Item $item, ?CreativeInfo $creativeInfo = null): void
     {
         $version = ItemVersion::fromItem($item);
         if ($version->equals(ItemVersion::LEGACY)) {
@@ -39,7 +39,7 @@ class NexlyItems
      * @param bool $autoload
      * @return void
      */
-    public static function registerLegacy(string $stringId, Item $item, CreativeInfo $creativeInfo = null, bool $autoload = true): void
+    public static function registerLegacy(string $stringId, Item $item, ?CreativeInfo $creativeInfo = null, bool $autoload = true): void
     {
         $version = ItemVersion::fromItem($item);
         if ($version !== ItemVersion::LEGACY) {
@@ -79,7 +79,7 @@ class NexlyItems
      * @param bool $initComponents
      * @return void
      */
-    public static function registerDataDriven(string $stringId, Item $item, CreativeInfo $creativeInfo = null, bool $initProperties = true, bool $initComponents = true): void
+    public static function registerDataDriven(string $stringId, Item $item, ?CreativeInfo $creativeInfo = null, bool $initProperties = true, bool $initComponents = true): void
     {
         $version = ItemVersion::fromItem($item);
         if ($version !== ItemVersion::DATA_DRIVEN) {

--- a/src/Listener/BlockBreakingListener.php
+++ b/src/Listener/BlockBreakingListener.php
@@ -33,7 +33,7 @@ final class BlockBreakingListener implements Listener
     private const MAX_BLOCK_ACTIONS = 100;
     private const MAX_DIST_SQ = 10_000;
 
-    /** @var WeakMap<Player, SurvivalBlockBreakHandler|null> */
+    /** @var WeakMap<Player, SurvivalBlockBreakHandler> */
     private WeakMap $breakHandlers;
 
     /** Réflexion mise en cache */

--- a/src/Mappings/BlockMappings.php
+++ b/src/Mappings/BlockMappings.php
@@ -14,6 +14,8 @@ class BlockMappings
      * @var array<string, BlockMapping> Mapping of block string IDs to their BlockMapping instances.
      */
     private array $mappings = [];
+
+    /** @var list<BlockPaletteEntry> */
     private array $entries = [];
 
     /**
@@ -25,7 +27,7 @@ class BlockMappings
     }
 
     /**
-     * @return array
+     * @return array<string, BlockMapping>
      */
     public function getMappings(): array
     {
@@ -33,7 +35,7 @@ class BlockMappings
     }
 
     /**
-     * @param array $mappings
+     * @param array<string, BlockMapping> $mappings
      */
     public function setMappings(array $mappings): void
     {
@@ -41,7 +43,7 @@ class BlockMappings
     }
 
     /**
-     * @return array
+     * @return list<BlockPaletteEntry>
      */
     public function getEntries(): array
     {
@@ -49,7 +51,7 @@ class BlockMappings
     }
 
     /**
-     * @param array $entries
+     * @param list<BlockPaletteEntry> $entries
      */
     public function setEntries(array $entries): void
     {

--- a/src/Mappings/ItemMappings.php
+++ b/src/Mappings/ItemMappings.php
@@ -13,12 +13,12 @@ class ItemMappings
     use SingletonTrait;
 
     /**
-     * @var array<string, array> Mapping of item string IDs to their numeric IDs.
+     * @var array<string, array{builder: ItemBuilder, entry: ItemTypeEntry}>
      */
     private array $mappings = [];
 
     /**
-     * @return array
+     * @return array<string, array{builder: ItemBuilder, entry: ItemTypeEntry}>
      */
     public function getMappings(): array
     {
@@ -26,7 +26,7 @@ class ItemMappings
     }
 
     /**
-     * @param array $mappings
+     * @param array<string, array{builder: ItemBuilder, entry: ItemTypeEntry}> $mappings
      */
     public function setMappings(array $mappings): void
     {
@@ -48,7 +48,7 @@ class ItemMappings
         $this->mappings[$entry->getStringId()] = ["builder" => $builder, "entry" => $entry];
 
         try {
-            $this->registerEntry($entry);
+            self::registerEntry($entry);
         } catch (ReflectionException $e) {
             throw new \RuntimeException("Failed to register item entry: " . $e->getMessage(), 0, $e);
         }
@@ -58,7 +58,7 @@ class ItemMappings
      * Retrieves the mapping for a given item string ID.
      *
      * @param string $stringId
-     * @return array|null
+     * @return array{builder: ItemBuilder, entry: ItemTypeEntry}|null
      */
     public function getMapping(string $stringId): ?array
     {
@@ -81,16 +81,17 @@ class ItemMappings
         $reflection = new \ReflectionClass($dictionary);
 
         $intToString = $reflection->getProperty("intToStringIdMap");
-        /** @var int[] $value */
+        /** @var array<int, string> $value */
         $value = $intToString->getValue($dictionary);
         $intToString->setValue($dictionary, $value + [$numericId => $stringId]);
 
         $stringToInt = $reflection->getProperty("stringToIntMap");
-        /** @var int[] $value */
+        /** @var array<string, int> $value */
         $value = $stringToInt->getValue($dictionary);
         $stringToInt->setValue($dictionary, $value + [$stringId => $numericId]);
 
         $itemTypes = $reflection->getProperty("itemTypes");
+        /** @var list<ItemTypeEntry> $value */
         $value = $itemTypes->getValue($dictionary);
         $value[] = $entry;
         $itemTypes->setValue($dictionary, $value);

--- a/src/Recipes/MinecraftShape.php
+++ b/src/Recipes/MinecraftShape.php
@@ -25,7 +25,7 @@ enum MinecraftShape: string
     case STICK = "A\nA";
 
     /**
-     * @return string[]
+     * @return non-empty-list<string>
      */
     public function toArray(): array
     {

--- a/src/Recipes/NexlyRecipes.php
+++ b/src/Recipes/NexlyRecipes.php
@@ -5,6 +5,7 @@ namespace Nexly\Recipes;
 use Nexly\Recipes\Types\Recipe;
 use Nexly\Recipes\Types\ShapedRecipe;
 use Nexly\Recipes\Types\ShapelessRecipe;
+use pocketmine\crafting\ShapedRecipe as ShapedRecipePM;
 use pocketmine\crafting\ShapelessRecipe as ShapelessRecipePM;
 use pocketmine\crafting\ShapelessRecipeType;
 use pocketmine\item\StringToItemParser;
@@ -15,7 +16,7 @@ class NexlyRecipes
 {
     use SingletonTrait;
 
-    /** @var \Closure[] */
+    /** @var list<\Closure(): Recipe> */
     private array $recipes = [];
 
     public function __construct()
@@ -24,7 +25,7 @@ class NexlyRecipes
     }
 
     /**
-     * @return array
+     * @return list<\Closure(): Recipe>
      */
     public function getRecipes(): array
     {
@@ -32,7 +33,7 @@ class NexlyRecipes
     }
 
     /**
-     * @param array $recipes
+     * @param list<\Closure(): Recipe> $recipes
      */
     public function setRecipes(array $recipes): void
     {
@@ -40,7 +41,7 @@ class NexlyRecipes
     }
 
     /**
-     * @param \Closure $recipe
+     * @param \Closure(): Recipe $recipe
      */
     public function addRecipe(\Closure $recipe): void
     {
@@ -50,7 +51,7 @@ class NexlyRecipes
     /**
      * Loads a recipe from an associative array.
      *
-     * @param array $data
+     * @param array<string, mixed> $data
      * @return void
      */
     public function fromArray(array $data): void
@@ -112,17 +113,13 @@ class NexlyRecipes
     /**
      * Loads recipes from a JSON array.
      *
-     * @param array $data
+     * @param list<array<string, mixed>> $data
      * @return void
      */
     public function fromJson(array $data): void
     {
         foreach ($data as $recipe) {
-            if (is_array($recipe)) {
-                $this->fromArray($recipe);
-            } else {
-                throw new \InvalidArgumentException("Invalid recipe format, expected array");
-            }
+            $this->fromArray($recipe);
         }
     }
 
@@ -141,15 +138,13 @@ class NexlyRecipes
                 continue;
             }
 
-            if (!$recipe instanceof Recipe) {
-                continue;
-            }
-
             $craftingRecipe = $recipe->build();
             if ($craftingRecipe instanceof ShapelessRecipePM) {
                 $craftingManager->registerShapelessRecipe($craftingRecipe);
-            } else {
+            } elseif ($craftingRecipe instanceof ShapedRecipePM) {
                 $craftingManager->registerShapedRecipe($craftingRecipe);
+            } else {
+                throw new \UnexpectedValueException("Unsupported crafting recipe type: " . $craftingRecipe::class);
             }
         }
     }

--- a/src/Recipes/Types/ShapedRecipe.php
+++ b/src/Recipes/Types/ShapedRecipe.php
@@ -12,23 +12,29 @@ use pocketmine\item\StringToItemParser;
 #[Attribute(Attribute::TARGET_CLASS)]
 class ShapedRecipe implements Recipe
 {
+    /** @var non-empty-list<string> */
+    private array $shape;
+
     /**
-     * @param MinecraftShape|string[] $shape
-     * @param Item|string[] $ingredients
-     * @param Item|string[] $outputs
+     * @param MinecraftShape|list<string> $shape
+     * @param array<string, Item|string> $ingredients
+     * @param list<Item|string> $outputs
      */
     public function __construct(
-        private MinecraftShape|array $shape,
+        MinecraftShape|array $shape,
         private readonly array       $ingredients,
         private readonly array       $outputs
     ) {
-        if ($this->shape instanceof MinecraftShape) {
-            $this->shape = $this->shape->toArray();
+        $resolvedShape = $shape instanceof MinecraftShape ? $shape->toArray() : $shape;
+        if ($resolvedShape === []) {
+            throw new \InvalidArgumentException("A shaped recipe must contain at least one row.");
         }
+
+        $this->shape = $resolvedShape;
     }
 
     /**
-     * @return array
+     * @return non-empty-list<string>
      */
     public function getShape(): array
     {
@@ -36,7 +42,7 @@ class ShapedRecipe implements Recipe
     }
 
     /**
-     * @return array
+     * @return array<string, Item|string>
      */
     public function getIngredients(): array
     {
@@ -44,7 +50,7 @@ class ShapedRecipe implements Recipe
     }
 
     /**
-     * @return string[]
+     * @return list<Item|string>
      */
     public function getOutputs(): array
     {
@@ -60,8 +66,18 @@ class ShapedRecipe implements Recipe
     {
         return new ShapedRecipePM(
             $this->shape,
-            array_map(fn ($ingredient) => new ExactRecipeIngredient(is_string($ingredient) ? StringToItemParser::getInstance()->parse($ingredient) : $ingredient), $this->ingredients),
-            array_map(fn ($output) => is_string($output) ? StringToItemParser::getInstance()->parse($output) : $output, $this->outputs),
+            array_map(fn (Item|string $ingredient): ExactRecipeIngredient => new ExactRecipeIngredient(self::resolveItem($ingredient)), $this->ingredients),
+            array_map(fn (Item|string $output): Item => self::resolveItem($output), $this->outputs),
         );
+    }
+
+    private static function resolveItem(Item|string $item): Item
+    {
+        if ($item instanceof Item) {
+            return $item;
+        }
+
+        return StringToItemParser::getInstance()->parse($item)
+            ?? throw new \InvalidArgumentException("Unknown recipe item identifier: $item");
     }
 }

--- a/src/Recipes/Types/ShapelessRecipe.php
+++ b/src/Recipes/Types/ShapelessRecipe.php
@@ -14,8 +14,8 @@ class ShapelessRecipe implements Recipe
 {
     /**
      * @param ShapelessRecipeType $type
-     * @param Item|string[] $ingredients
-     * @param Item|string[] $outputs
+     * @param list<Item|string> $ingredients
+     * @param list<Item|string> $outputs
      */
     public function __construct(
         private readonly ShapelessRecipeType $type,
@@ -33,7 +33,7 @@ class ShapelessRecipe implements Recipe
     }
 
     /**
-     * @return array
+     * @return list<Item|string>
      */
     public function getIngredients(): array
     {
@@ -41,7 +41,7 @@ class ShapelessRecipe implements Recipe
     }
 
     /**
-     * @return array
+     * @return list<Item|string>
      */
     public function getOutputs(): array
     {
@@ -56,9 +56,19 @@ class ShapelessRecipe implements Recipe
     public function build(): ShapelessRecipePM
     {
         return new ShapelessRecipePM(
-            array_map(fn ($ingredient) => new ExactRecipeIngredient(is_string($ingredient) ? StringToItemParser::getInstance()->parse($ingredient) : $ingredient), $this->ingredients),
-            array_map(fn ($output) => is_string($output) ? StringToItemParser::getInstance()->parse($output) : $output, $this->outputs),
+            array_map(fn (Item|string $ingredient): ExactRecipeIngredient => new ExactRecipeIngredient(self::resolveItem($ingredient)), $this->ingredients),
+            array_map(fn (Item|string $output): Item => self::resolveItem($output), $this->outputs),
             $this->type
         );
+    }
+
+    private static function resolveItem(Item|string $item): Item
+    {
+        if ($item instanceof Item) {
+            return $item;
+        }
+
+        return StringToItemParser::getInstance()->parse($item)
+            ?? throw new \InvalidArgumentException("Unknown recipe item identifier: $item");
     }
 }

--- a/src/Tasks/AsyncRegisterBlocksTask.php
+++ b/src/Tasks/AsyncRegisterBlocksTask.php
@@ -2,6 +2,7 @@
 
 namespace Nexly\Tasks;
 
+use Closure;
 use Nexly\Blocks\BlockPalette;
 use Nexly\Blocks\Components\AsyncBlockComponent;
 use Nexly\Blocks\NexlyBlocks;
@@ -16,6 +17,18 @@ use pocketmine\data\bedrock\block\convert\BlockStateReader;
 use pocketmine\data\bedrock\block\convert\BlockStateWriter;
 use pocketmine\scheduler\AsyncTask;
 
+/**
+ * @phpstan-type AsyncBlockDefinition array{
+ *     int,
+ *     Closure(int): Block,
+ *     string,
+ *     string,
+ *     string,
+ *     string,
+ *     Closure(mixed...): BlockStateWriter,
+ *     Closure(BlockStateReader): Block
+ * }
+ */
 final class AsyncRegisterBlocksTask extends AsyncTask
 {
     private ThreadSafeArray $numericIds;
@@ -28,8 +41,7 @@ final class AsyncRegisterBlocksTask extends AsyncTask
     private ThreadSafeArray $deserializer;
 
     /**
-     * @param Closure[] $blocks
-     * @phpstan-param array<string, array{(Closure(int): Block), (Closure(BlockStateWriter): Block), (Closure(Block): BlockStateReader)}> $blocks
+     * @param array<string, AsyncBlockDefinition> $blocks
      */
     public function __construct(array $blocks)
     {
@@ -89,7 +101,7 @@ final class AsyncRegisterBlocksTask extends AsyncTask
                 }
 
                 $rotationOffset = $trait["rotationOffset"] ?? null;
-                if (!is_numeric($rotationOffset)) {
+                if (!is_int($rotationOffset) && !is_float($rotationOffset)) {
                     throw new \InvalidArgumentException("Invalid rotationOffset for trait " . $rotationOffset);
                 }
 


### PR DESCRIPTION
## Summary

Modernizes Nexly's block and item component definitions to better match current Minecraft Bedrock schemas, while improving validation, typing, and registration reliability.

## Changes

- Updated block component serialization and registration
- Added missing block component types and connection options
- Modernized data-driven item components and their NBT fields
- Added reusable item types for ranges, cooldown actions, usage behavior, and kinetic effects
- Improved validation of component parameters and recipe definitions
- Hardened event listener registration and cleanup
- Improved type declarations and callback return types
- Added explicit errors for invalid or unknown recipe item identifiers

## Compatibility notes

Some component constructor parameters, defaults, and serialized NBT fields have changed. Projects using these components directly may require minor adjustments.